### PR TITLE
Small tweaks for feature/TRAC-9711

### DIFF
--- a/manta/src/main/java/ch/cyberduck/core/manta/MantaObjectAttributeAdapter.java
+++ b/manta/src/main/java/ch/cyberduck/core/manta/MantaObjectAttributeAdapter.java
@@ -19,6 +19,7 @@ import ch.cyberduck.core.DescriptiveUrl;
 import ch.cyberduck.core.Path;
 import ch.cyberduck.core.PathAttributes;
 import ch.cyberduck.core.Permission;
+import ch.cyberduck.core.URIEncoder;
 import ch.cyberduck.core.io.Checksum;
 import ch.cyberduck.core.io.HashAlgorithm;
 
@@ -56,7 +57,7 @@ public final class MantaObjectAttributeAdapter {
         }
         if(session.isWorldReadable(object)) {
             // mantaObject.getPath() starts with /
-            final String joinedPath = session.getHost().getWebURL() + object.getPath();
+            final String joinedPath = session.getHost().getWebURL() + URIEncoder.encode(object.getPath());
 
             try {
                 final URI link = new URI(joinedPath);

--- a/manta/src/main/java/ch/cyberduck/core/manta/MantaPublicKeyAuthentication.java
+++ b/manta/src/main/java/ch/cyberduck/core/manta/MantaPublicKeyAuthentication.java
@@ -84,7 +84,7 @@ public class MantaPublicKeyAuthentication implements AuthenticationProvider<Stri
                                 String.format("%s (%s)",
                                     LocaleFactory.localizedString("Enter the passphrase for the private key file", "Credentials"),
                                     identity.getAbbreviatedPath()), new LoginOptions(bookmark.getProtocol())
-                                    .user(false).password(true)
+                                    .user(false).password(true).publickey(false)
                             ).getPassword();
                         }
                         catch(LoginCanceledException ignored) {


### PR DESCRIPTION
- Disabling Private Key File dropdown when inputting password. The enabled dropdown could confuse users about which key is actually being used.
- URL encoding for the link attribute 