### PR TITLE
duck.sh URL format output fix

### DIFF
--- a/cli/src/main/java/ch/cyberduck/cli/TerminalHelpPrinter.java
+++ b/cli/src/main/java/ch/cyberduck/cli/TerminalHelpPrinter.java
@@ -56,10 +56,10 @@ public final class TerminalHelpPrinter {
                 case s3:
                 case googlestorage:
                 case swift:
-                    protocols.append("\t").append(String.format("%s://<container>/<key>", p.isBundled() ? p.getIdentifier() : p.getProvider()));
+                    protocols.append("\t").append(String.format("%s://<container>/<key>", p.getIdentifier()));
                     break;
                 default:
-                    protocols.append("\t").append(String.format("%s://<hostname>/<folder>/<file>", p.isBundled() ? p.getIdentifier() : p.getProvider()));
+                    protocols.append("\t").append(String.format("%s://<hostname>/<folder>/<file>", p.getIdentifier()));
                     break;
             }
             protocols.append(StringUtils.LF);


### PR DESCRIPTION
Resolves https://trac.cyberduck.io/ticket/10156

Old output:

```
Windows Azure Storage
	azure://<hostname>/<folder>/<file>
Backblaze B2 Cloud Storage
	b2://<hostname>/<folder>/<file>
WebDAV (HTTP)
	dav://<hostname>/<folder>/<file>
WebDAV (HTTPS)
	davs://<hostname>/<folder>/<file>
DRACOON (Email Address)
	dracoon://<hostname>/<folder>/<file>
Dropbox
	dropbox://<hostname>/<folder>/<file>
xeonbook.local
	file://<hostname>/<folder>/<file>
FTP (File Transfer Protocol)
	ftp://<hostname>/<folder>/<file>
FTP-SSL (Explicit AUTH TLS)
	ftps://<hostname>/<folder>/<file>
Google Drive
	googledrive://<hostname>/<folder>/<file>
Google Cloud Storage
	gs://<container>/<key>
Joyent Triton Object Storage (us-east)
	iterate GmbH://<hostname>/<folder>/<file>         ( <--- )
Microsoft OneDrive
	onedrive://<hostname>/<folder>/<file>
Amazon S3
	s3://<container>/<key>
SFTP (SSH File Transfer Protocol)
	sftp://<hostname>/<folder>/<file>
Rackspace Cloud Files (US)
	swift://<container>/<key>
Swift (OpenStack Object Storage)
	swift://<container>/<key>
```


New output:

```
Windows Azure Storage
	azure://<hostname>/<folder>/<file>
Backblaze B2 Cloud Storage
	b2://<hostname>/<folder>/<file>
WebDAV (HTTP)
	dav://<hostname>/<folder>/<file>
WebDAV (HTTPS)
	davs://<hostname>/<folder>/<file>
DRACOON (Email Address)
	dracoon://<hostname>/<folder>/<file>
Dropbox
	dropbox://<hostname>/<folder>/<file>
xeonbook.local
	file://<hostname>/<folder>/<file>
FTP (File Transfer Protocol)
	ftp://<hostname>/<folder>/<file>
FTP-SSL (Explicit AUTH TLS)
	ftps://<hostname>/<folder>/<file>
Google Drive
	googledrive://<hostname>/<folder>/<file>
Google Cloud Storage
	gs://<container>/<key>
Joyent Triton Object Storage (us-east)
	manta://<hostname>/<folder>/<file>                 ( <--- )
Microsoft OneDrive
	onedrive://<hostname>/<folder>/<file>
Amazon S3
	s3://<container>/<key>
SFTP (SSH File Transfer Protocol)
	sftp://<hostname>/<folder>/<file>
Rackspace Cloud Files (US)
	swift://<container>/<key>
Swift (OpenStack Object Storage)
	swift://<container>/<key>
```