### PR TITLE
Do not use sudo in the scripts of the debian package.

### DIFF
--- a/setup/deb/duck.postinstall
+++ b/setup/deb/duck.postinstall
@@ -1,1 +1,1 @@
-sudo ln -sf /opt/duck/duck /usr/local/bin/duck
+ln -sf /opt/duck/duck /usr/local/bin/duck

--- a/setup/deb/duck.postrm
+++ b/setup/deb/duck.postrm
@@ -1,1 +1,1 @@
-sudo rm -f /usr/local/bin/duck
+rm -f /usr/local/bin/duck


### PR DESCRIPTION
Package installation is done as _root_ anyways, so there is no need to call `sudo`, right?

When installing the software on a system without the `sudo` package (e.g. on a docker image), the installation would fail, beacuse the `sudo` package is not listed as a dependency.