### PR TITLE
Use STANDARD for default google storage class

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/preferences/Preferences.java
+++ b/core/src/main/java/ch/cyberduck/core/preferences/Preferences.java
@@ -725,7 +725,7 @@ public abstract class Preferences implements Locales {
 
         this.setDefault("googlestorage.listing.chunksize", String.valueOf(1000));
         this.setDefault("googlestorage.metadata.default", StringUtils.EMPTY);
-        this.setDefault("googlestorage.storage.class", "multi_regional");
+        this.setDefault("googlestorage.storage.class", "STANDARD");
 
 
         this.setDefault("onedrive.listing.chunksize", String.valueOf(1000));


### PR DESCRIPTION
This should fix https://trac.cyberduck.io/ticket/11062

`multi_regional` is no longer recommended for use.
It is equivalent to standard but only works with Multi-Regional buckets.

See https://cloud.google.com/storage/docs/storage-classes#legacy