### PR TITLE
Add SUFeedURL to Info.plist on macOS

### DIFF
--- a/setup/app/Info.plist
+++ b/setup/app/Info.plist
@@ -272,6 +272,8 @@
         <string>update.pem</string>
         <key>SUExpectsDSASignature</key>
         <true/>
+        <key>SUFeedURL</key>
+        <string>${SPARKLEFEED}</string>
         #endif
         <key>NSServices</key>
         <array>


### PR DESCRIPTION
This fixes TRAC ticket https://trac.cyberduck.io/ticket/11219 .

The default url of https://version.cyberduck.io/local/changelog.rss built with this patch does not work - I assume this string will be left empty on release build as https://version.cyberduck.io//changelog.rss does work.