### PR TITLE
Fix null dereference on case sensitive get of storage-class header

### DIFF
--- a/s3/src/main/java/ch/cyberduck/core/s3/S3AttributesFinderFeature.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3AttributesFinderFeature.java
@@ -175,7 +175,7 @@ public class S3AttributesFinderFeature implements AttributesFinder {
             attributes.setStorageClass(object.getStorageClass());
         }
         else if(object.containsMetadata("storage-class")) {
-            attributes.setStorageClass(object.getMetadataMap().get("storage-class").toString());
+            attributes.setStorageClass(object.getMetadata("storage-class").toString());
         }
         if(StringUtils.isNotBlank(object.getETag())) {
             attributes.setETag(object.getETag());


### PR DESCRIPTION
Make code to get "storage-class" attribute of object in case-insensitive manner.

Before this fix we could break on `<null>.toString()` call inside `attributes.setStorageClass()`.
This is because of `object.containsMetadata()` is case-insensitive check and it gives 'true' for "Storage-Class" object attribute, while `object.getMetadataMap().get("storage-class")` is case sensitive and gives `null` for the same data.

This logic flaw strikes for some of alternative S3-compatible services. Camel-Cased headers do not contradict to HTTP/1.X standard and web-servers may modify response headers on the way to client. E.g. nginx can transform headers case before sending response to the client.