### PR TITLE
Add possibility to override InstallFolder variable

### DIFF
--- a/cli/src/main/wix/Bootstrapper/Cyberduck CLI Bundle.wxs
+++ b/cli/src/main/wix/Bootstrapper/Cyberduck CLI Bundle.wxs
@@ -7,7 +7,7 @@
       <bal:WixStandardBootstrapperApplication LicenseUrl=""      
         LogoFile="$(var.SetupDir)banner.png" LogoSideFile="$(var.SetupDir)welcome.bmp" />
     </BootstrapperApplicationRef>
-    <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]Cyberduck CLI" />
+    <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]Cyberduck CLI" bal:Overridable="yes" />
     <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="Software\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder" />
     <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="InstallFolder" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
     <Chain>

--- a/windows/src/main/wix/Bootstrapper/Cyberduck Bootstrapper.wxs
+++ b/windows/src/main/wix/Bootstrapper/Cyberduck Bootstrapper.wxs
@@ -8,7 +8,7 @@
                                               LogoFile="$(var.SetupDir)banner.png"
                                               LogoSideFile="$(var.SetupDir)welcome.bmp"/>
     </BootstrapperApplicationRef>
-    <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]Cyberduck"/>
+    <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]Cyberduck" bal:Overridable="yes" />
     <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="Software\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder" />
     <util:RegistrySearch Id="CurrentBuild" Variable="CBNumber" Result="value" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Value="CurrentBuildNumber"/>
     <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="InstallFolder" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />


### PR DESCRIPTION
I would like to install Cyberduck by command line *without admin rights*.

When I try to launch this:
```
Cyberduck-Installer-7.9.1.34974.exe  /install /quiet /norestart /log log.txt InstallFolder=%USERPROFILE%/bin/cyberduck
```

I have in the log.txt file : 
```
 Initializing string variable 'InstallFolder' to value '[ProgramFiles64Folder]Cyberduck'
 [...]
 Ignoring attempt to set non-overridable variable: 'InstallFolder'.
```

I have added this flag `bal:Overridable="yes"` on Wix config files for Windows & CLI


