### PR TITLE
Fix action of GroupReadChanged in InfoController

### DIFF
--- a/windows/src/main/csharp/ch/cyberduck/ui/controller/InfoController.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/controller/InfoController.cs
@@ -830,7 +830,7 @@ namespace Ch.Cyberduck.Ui.Controller
         private void GroupReadChanged()
         {
             DetachPermissionHandlers();
-            permissions.group.execute = View.GroupRead == CheckState.Checked ? Boolean.TRUE : Boolean.FALSE;
+            permissions.group.read = View.GroupRead == CheckState.Checked ? Boolean.TRUE : Boolean.FALSE;
             PermissionsChanged();
         }
 


### PR DESCRIPTION
`GroupReadChanged` sets the value of `permissions.group.execute` instead of `permissions.group.read`, which seems like a typo: it makes it impossible to correctly edit the Group Read permission from the UI and can affect the Group Execute permission instead.