### PR TITLE
Make Cyberduck authoritatively unaware of DPI

### DIFF
--- a/windows/src/main/csharp/ch/cyberduck/properties/app.manifest
+++ b/windows/src/main/csharp/ch/cyberduck/properties/app.manifest
@@ -38,6 +38,8 @@
   </compatibility>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">unaware</dpiAwareness>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>


### PR DESCRIPTION
Windows 11 doesn't care about whether Dpi Awareness is set, and implicitly assumes every app is.
This forces Windows to just scale everything up. This is blurry, but works better than having a cut-up UI.

Resolves #12742.