### PR TITLE
Implement the wrapper around named pipes

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -286,10 +286,13 @@ public class SFTPSession extends Session<SSHClient> {
                 switch(Factory.Platform.getDefault()) {
                     case windows:
                         defaultMethods.add(new SFTPAgentAuthentication(client, new PageantAuthenticator()));
-                        // Break through
+                        
+                        defaultMethods.add(new SFTPAgentAuthentication(client, new OpenSSHAgentAuthenticator(
+                                new OpenSSHIdentityAgentConfigurator().getIdentityAgent(host.getHostname()), true)));
+                        break;
                     default:
                         defaultMethods.add(new SFTPAgentAuthentication(client, new OpenSSHAgentAuthenticator(
-                                new OpenSSHIdentityAgentConfigurator().getIdentityAgent(host.getHostname()))));
+                                new OpenSSHIdentityAgentConfigurator().getIdentityAgent(host.getHostname()), false)));
                         break;
                 }
             }

--- a/ssh/src/test/java/ch/cyberduck/core/sftp/openssh/OpenSSHAgentAuthenticatorTest.java
+++ b/ssh/src/test/java/ch/cyberduck/core/sftp/openssh/OpenSSHAgentAuthenticatorTest.java
@@ -33,7 +33,7 @@ public class OpenSSHAgentAuthenticatorTest {
     @Test
     @Ignore
     public void testGetIdentities() {
-        final OpenSSHAgentAuthenticator authenticator = new OpenSSHAgentAuthenticator(null);
+        final OpenSSHAgentAuthenticator authenticator = new OpenSSHAgentAuthenticator(null, false);
         final Collection<Identity> identities = authenticator.getIdentities();
         assertNotNull(authenticator.getProxy());
         assertFalse(identities.isEmpty());


### PR DESCRIPTION
Adds an implementation for a socket based off the general idea described in ymnk/jsch-agent-proxy#34

Should remedy the issue faced in #12882 regarding named pipes, if the issue below can be fixed.

This general approach seems to work when running similar code using the
JVM, yet seems to fail when used in conjunction with Cyberduck:
```
java.io.FileNotFoundException: 'FileStream was asked to open a device that was not a file. For support for devices like 'com1:' or 'lpt1:', call CreateFile, then use the FileStream constructors that take an OS handle as an IntPtr.'

This exception was originally thrown at this call stack:
    java.io.FileDescriptor.open(string, int, int)
    java.io.FileDescriptor.openReadWrite(string)
    java.io.RandomAccessFile.open(string, int)
    java.io.RandomAccessFile.RandomAccessFile(java.io.File, string)
    java.io.RandomAccessFile.RandomAccessFile(string, string)
    ch.cyberduck.core.sftp.openssh.RandomAccessFileSocketFactory.WindowsSocket.WindowsSocket(ch.cyberduck.core.sftp.openssh.RandomAccessFileSocketFactory, string) in OpenSSHAgentAuthenticator.java
    ch.cyberduck.core.sftp.openssh.RandomAccessFileSocketFactory.open(string) in OpenSSHAgentAuthenticator.java
    com.jcraft.jsch.agentproxy.connector.SSHAgentConnector.open() in SSHAgentConnector.java
    com.jcraft.jsch.agentproxy.connector.SSHAgentConnector.SSHAgentConnector(com.jcraft.jsch.agentproxy.USocketFactory, string) in SSHAgentConnector.java
```
Some Googling indicates that this likely originates from C#,
so an alternate approach -- or a fix on the C# side -- may be necessary.