### PR TITLE
Lower memory pressure when submitting many tasks with limited queue s…

### DIFF
--- a/core/dylib/src/main/java/ch/cyberduck/core/threading/DispatchThreadPool.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/threading/DispatchThreadPool.java
@@ -27,6 +27,6 @@ public class DispatchThreadPool extends ExecutorServiceThreadPool implements Thr
 
     public DispatchThreadPool(final String prefix, final int size, final Priority priority, final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {
         super(PreferencesFactory.get().getInteger("threading.pool.size.max") == size ? new DispatchExecutorService() :
-            DefaultThreadPool.createExecutor(prefix, size, priority, queue, handler));
+                DefaultThreadPool.createExecutor(prefix, size, priority, queue, new DefaultThreadPool.CustomCallerPolicy(), handler));
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/threading/DefaultBackgroundExecutor.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/DefaultBackgroundExecutor.java
@@ -41,15 +41,15 @@ public class DefaultBackgroundExecutor implements BackgroundExecutor {
     }
 
     public DefaultBackgroundExecutor(final Thread.UncaughtExceptionHandler handler) {
-        this(ThreadPool.DEFAULT_THREAD_NAME_PREFIX, handler);
+        this(ThreadPool.DEFAULT_THREAD_NAME_PREFIX, Integer.MAX_VALUE, handler);
     }
 
     public DefaultBackgroundExecutor(final String prefix) {
-        this(prefix, new LoggingUncaughtExceptionHandler());
+        this(prefix, Integer.MAX_VALUE, new LoggingUncaughtExceptionHandler());
     }
 
-    public DefaultBackgroundExecutor(final String prefix, final Thread.UncaughtExceptionHandler handler) {
-        this(ThreadPoolFactory.get(prefix, handler));
+    public DefaultBackgroundExecutor(final String prefix, final int size, final Thread.UncaughtExceptionHandler handler) {
+        this(ThreadPoolFactory.get(prefix, size, handler));
     }
 
     public DefaultBackgroundExecutor(final ThreadPool concurrentExecutor) {

--- a/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
@@ -20,8 +20,12 @@ package ch.cyberduck.core.threading;
 
 import ch.cyberduck.core.preferences.PreferencesFactory;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -74,19 +78,21 @@ public class DefaultThreadPool extends ExecutorServiceThreadPool {
     }
 
     public DefaultThreadPool(final String prefix, final int size, final Priority priority, final Thread.UncaughtExceptionHandler handler) {
-        super(createExecutor(prefix, size, priority, new LinkedBlockingQueue<>(size), handler));
+        super(createExecutor(prefix, size, priority, new LinkedBlockingQueue<>(size), new CustomCallerPolicy(), handler));
     }
 
-    public DefaultThreadPool(final String prefix, final int size, final Priority priority, final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {
-        super(createExecutor(prefix, size, priority, queue, handler));
+    public DefaultThreadPool(final String prefix, final int size, final Priority priority, final BlockingQueue<Runnable> queue,
+                             final RejectedExecutionHandler policy, final Thread.UncaughtExceptionHandler handler) {
+        super(createExecutor(prefix, size, priority, queue, policy, handler));
     }
 
     public static ThreadPoolExecutor createExecutor(final String prefix, final int size, final Priority priority,
                                                     final BlockingQueue<Runnable> queue,
+                                                    final RejectedExecutionHandler policy,
                                                     final Thread.UncaughtExceptionHandler handler) {
         return new ThreadPoolExecutor(size, size,
                 PreferencesFactory.get().getLong("threading.pool.keepalive.seconds"), TimeUnit.SECONDS,
-                queue, new NamedThreadFactory(prefix, priority, handler), new ThreadPoolExecutor.CallerRunsPolicy()) {
+                queue, new NamedThreadFactory(prefix, priority, handler), policy) {
             @Override
             protected void afterExecute(final Runnable r, final Throwable t) {
                 if(t != null) {
@@ -95,4 +101,22 @@ public class DefaultThreadPool extends ExecutorServiceThreadPool {
             }
         };
     }
+
+    private static final class CustomCallerPolicy extends ThreadPoolExecutor.AbortPolicy {
+        private static final Logger log = LogManager.getLogger(CustomCallerPolicy.class);
+
+        @Override
+        public void rejectedExecution(final Runnable r, final ThreadPoolExecutor e) {
+            if(!e.isShutdown()) {
+                log.warn(String.format("Run %s on caller thread", r));
+                r.run();
+            }
+            else {
+                log.error(String.format("Rejected execution of %s", r));
+                // Reject
+                super.rejectedExecution(r, e);
+            }
+        }
+    }
+
 }

--- a/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
@@ -102,7 +102,7 @@ public class DefaultThreadPool extends ExecutorServiceThreadPool {
         };
     }
 
-    private static final class CustomCallerPolicy extends ThreadPoolExecutor.AbortPolicy {
+    public static final class CustomCallerPolicy extends ThreadPoolExecutor.AbortPolicy {
         private static final Logger log = LogManager.getLogger(CustomCallerPolicy.class);
 
         @Override

--- a/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/DefaultThreadPool.java
@@ -74,18 +74,19 @@ public class DefaultThreadPool extends ExecutorServiceThreadPool {
     }
 
     public DefaultThreadPool(final String prefix, final int size, final Priority priority, final Thread.UncaughtExceptionHandler handler) {
-        super(createExecutor(prefix, size, priority, new LinkedBlockingQueue<>(), handler));
+        super(createExecutor(prefix, size, priority, new LinkedBlockingQueue<>(size), handler));
     }
 
     public DefaultThreadPool(final String prefix, final int size, final Priority priority, final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {
         super(createExecutor(prefix, size, priority, queue, handler));
     }
 
-    public static ThreadPoolExecutor createExecutor(final String prefix, final int size, final Priority priority, final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {
+    public static ThreadPoolExecutor createExecutor(final String prefix, final int size, final Priority priority,
+                                                    final BlockingQueue<Runnable> queue,
+                                                    final Thread.UncaughtExceptionHandler handler) {
         return new ThreadPoolExecutor(size, size,
-            PreferencesFactory.get().getLong("threading.pool.keepalive.seconds"), TimeUnit.SECONDS,
-            queue,
-            new NamedThreadFactory(prefix, priority, handler)) {
+                PreferencesFactory.get().getLong("threading.pool.keepalive.seconds"), TimeUnit.SECONDS,
+                queue, new NamedThreadFactory(prefix, priority, handler), new ThreadPoolExecutor.CallerRunsPolicy()) {
             @Override
             protected void afterExecute(final Runnable r, final Throwable t) {
                 if(t != null) {

--- a/core/src/main/java/ch/cyberduck/core/threading/ThreadPoolFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/ThreadPoolFactory.java
@@ -100,7 +100,7 @@ public class ThreadPoolFactory extends Factory<ThreadPool> {
     }
 
     public static ThreadPool get(final String prefix, final int size, final ThreadPool.Priority priority, final Thread.UncaughtExceptionHandler handler) {
-        return get(prefix, size, priority, new LinkedBlockingQueue<>(), handler);
+        return get(prefix, size, priority, new LinkedBlockingQueue<>(size), handler);
     }
 
     public static ThreadPool get(final String prefix, final int size, final ThreadPool.Priority priority, final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {

--- a/core/src/main/java/ch/cyberduck/core/threading/ThreadPoolFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/ThreadPoolFactory.java
@@ -38,15 +38,18 @@ public class ThreadPoolFactory extends Factory<ThreadPool> {
     }
 
     /**
+     * @param prefix   Thread name
      * @param size     Maximum pool size
      * @param priority Thread priority
+     * @param queue    Queue with pending tasks
      * @param handler  Uncaught thread exception handler
+     * @return Thread pool
      */
     protected ThreadPool create(final String prefix, final Integer size, final ThreadPool.Priority priority,
                                 final BlockingQueue<Runnable> queue, final Thread.UncaughtExceptionHandler handler) {
         try {
             final Constructor<ThreadPool> constructor = ConstructorUtils.getMatchingAccessibleConstructor(clazz,
-                prefix.getClass(), size.getClass(), priority.getClass(), queue.getClass(), handler.getClass());
+                    prefix.getClass(), size.getClass(), priority.getClass(), queue.getClass(), handler.getClass());
             if(null == constructor) {
                 log.warn(String.format("No matching constructor for parameter %s", handler.getClass()));
                 // Call default constructor for disabled implementations


### PR DESCRIPTION
…ize equal to the number of threads in the pool and run the task on the caller thread in case the queue fills up to allow catching up.