### PR TITLE
ssh config parsing: expand ~ in IdentityAgent path

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/OpenSSHIdentityAgentConfigurator.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/OpenSSHIdentityAgentConfigurator.java
@@ -18,6 +18,7 @@ package ch.cyberduck.core.sftp.openssh;
  * dkocher@cyberduck.ch
  */
 
+import ch.cyberduck.core.Local;
 import ch.cyberduck.core.LocalFactory;
 import ch.cyberduck.core.sftp.openssh.config.transport.OpenSshConfig;
 
@@ -33,7 +34,11 @@ public class OpenSSHIdentityAgentConfigurator {
     }
 
     public String getIdentityAgent(final String alias) {
-        return configuration.lookup(alias).getIdentityAgent();
+        final Local agent = configuration.lookup(alias).getIdentityAgent();
+        if(null == agent) {
+            return null;
+        }
+        return agent.getAbsolute();
     }
 
     @Override

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/config/transport/OpenSshConfig.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/config/transport/OpenSshConfig.java
@@ -230,7 +230,7 @@ public class OpenSshConfig {
             else if("IdentityAgent".equalsIgnoreCase(keyword)) {
                 for(final Host c : current) {
                     if(c.identityAgent == null) {
-                        c.identityAgent = dequote(argValue);
+                        c.identityAgent = LocalFactory.get(dequote(argValue));
                     }
                 }
             }
@@ -316,7 +316,7 @@ public class OpenSshConfig {
         String proxyJump;
         int port;
         Local identityFile;
-        String identityAgent;
+        Local identityAgent;
         String user;
         String preferredAuthentications;
         Boolean identitiesOnly;
@@ -381,7 +381,7 @@ public class OpenSshConfig {
         /**
          * @return Specifies the UNIX-domain socket used to communicate with the authentication agent.
          */
-        public String getIdentityAgent() {
+        public Local getIdentityAgent() {
             return identityAgent;
         }
 


### PR DESCRIPTION
Currently if a user has an option in their ssh config file like this:
`IdentityAgent ~/.1password/agent.sock`
then cyberduck can't open the socket because the ~ in the path isn't expanded, it's treated as a literal ~

(But `IdentityAgent /Users/myname/.1password/agent.sock` works correctly)

This PR applies the same logic to `IdentityAgent` as is already used for `IdentityFile`, so paths with ~ work correctly.

Thanks