### PR TITLE
If a thread is interrupted during such a call, the call continues to …

### DIFF
--- a/cryptomator/src/main/java/ch/cyberduck/core/cryptomator/features/CryptoChecksumCompute.java
+++ b/cryptomator/src/main/java/ch/cyberduck/core/cryptomator/features/CryptoChecksumCompute.java
@@ -48,6 +48,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+
 public class CryptoChecksumCompute extends AbstractChecksumCompute {
     private static final Logger log = LogManager.getLogger(CryptoChecksumCompute.class);
 
@@ -103,10 +105,7 @@ public class CryptoChecksumCompute extends AbstractChecksumCompute {
                 }
                 finally {
                     try {
-                        execute.get();
-                    }
-                    catch(InterruptedException e) {
-                        throw new ChecksumException(LocaleFactory.localizedString("Checksum failure", "Error"), e.getMessage(), e);
+                        Uninterruptibles.getUninterruptibly(execute);
                     }
                     catch(ExecutionException e) {
                         if(e.getCause() instanceof BackgroundException) {

--- a/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxCommonsHttpRequestExecutor.java
+++ b/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxCommonsHttpRequestExecutor.java
@@ -152,10 +152,7 @@ public class DropboxCommonsHttpRequestExecutor extends HttpRequestor implements 
             public Response finish() throws IOException {
                 final CloseableHttpResponse response;
                 try {
-                    response = future.get();
-                }
-                catch(InterruptedException e) {
-                    throw new IOException(e);
+                    response = Uninterruptibles.getUninterruptibly(future);
                 }
                 catch(ExecutionException e) {
                     throw new IOException(e.getCause());

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphCommonsHttpRequestExecutor.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphCommonsHttpRequestExecutor.java
@@ -115,10 +115,7 @@ public abstract class GraphCommonsHttpRequestExecutor implements RequestExecutor
             public Response getResponse() throws IOException {
                 final CloseableHttpResponse response;
                 try {
-                    response = future.get();
-                }
-                catch(InterruptedException e) {
-                    throw new IOException(e);
+                    response = Uninterruptibles.getUninterruptibly(future);
                 }
                 catch(ExecutionException e) {
                     throw new IOException(e.getCause());


### PR DESCRIPTION
…block until the result is available or the timeout elapses, and only then re-interrupts the thread.