### PR TITLE
ObjectListView isn't caching item icons

### DIFF
--- a/windows/src/main/csharp/ch/cyberduck/ui/controller/TreeBrowserModel.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/controller/TreeBrowserModel.cs
@@ -66,7 +66,7 @@ namespace Ch.Cyberduck.Ui.Controller
 
         public object GetIcon(Path path)
         {
-            if (path.isVolume())
+            if (_controller.IsMounted() && path.isVolume())
             {
                 return IconProvider.GetDisk(_controller.Session.getHost().getProtocol(), 16);
             }


### PR DESCRIPTION
After Disconnec the Controller Session Protocol is "disconnected", thus GetDisk throws NullRef.
Volume-check only works for mounted controllers.

Fixes #12975