### PR TITLE
ConnectionTimeout service handling min and max values

### DIFF
--- a/box/src/main/java/ch/cyberduck/core/box/BoxApiClient.java
+++ b/box/src/main/java/ch/cyberduck/core/box/BoxApiClient.java
@@ -15,6 +15,7 @@ package ch.cyberduck.core.box;
  * GNU General Public License for more details.
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.PreferencesUseragentProvider;
 import ch.cyberduck.core.box.io.swagger.client.ApiClient;
 import ch.cyberduck.core.box.io.swagger.client.ApiException;
@@ -46,7 +47,7 @@ public class BoxApiClient extends ApiClient {
             .register(JacksonFeature.class)
             .connectorProvider(new HttpComponentsProvider(client)))
         );
-        final int timeout = PreferencesFactory.get().getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         this.setConnectTimeout(timeout);
         this.setReadTimeout(timeout);
         this.setUserAgent(new PreferencesUseragentProvider().get());

--- a/brick/src/main/java/ch/cyberduck/core/brick/BrickApiClient.java
+++ b/brick/src/main/java/ch/cyberduck/core/brick/BrickApiClient.java
@@ -15,6 +15,7 @@ package ch.cyberduck.core.brick;
  * GNU General Public License for more details.
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.PreferencesUseragentProvider;
 import ch.cyberduck.core.brick.io.swagger.client.ApiClient;
 import ch.cyberduck.core.brick.io.swagger.client.ApiException;
@@ -45,7 +46,7 @@ public class BrickApiClient extends ApiClient {
             .register(JacksonFeature.class)
             .connectorProvider(new HttpComponentsProvider(session.getClient())))
         );
-        final int timeout = PreferencesFactory.get().getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         this.setConnectTimeout(timeout);
         this.setReadTimeout(timeout);
         this.setUserAgent(new PreferencesUseragentProvider().get());

--- a/cli/src/main/java/ch/cyberduck/cli/TerminalPreferences.java
+++ b/cli/src/main/java/ch/cyberduck/cli/TerminalPreferences.java
@@ -14,6 +14,7 @@
 
 package ch.cyberduck.cli;
 
+import ch.cyberduck.core.DisabledConnectionTimeout;
 import ch.cyberduck.core.Permission;
 import ch.cyberduck.core.cryptomator.CryptoVault;
 import ch.cyberduck.core.cryptomator.random.FastSecureRandomProvider;
@@ -57,6 +58,7 @@ public class TerminalPreferences extends Preferences {
         }
         this.setDefault("factory.vault.class", CryptoVault.class.getName());
         this.setDefault("factory.securerandom.class", FastSecureRandomProvider.class.getName());
+        this.setDefault("factory.connectiontimeout.class", DisabledConnectionTimeout.class.getName());
     }
 
     @Override

--- a/core/src/main/java/ch/cyberduck/core/ConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/ConnectionTimeout.java
@@ -1,0 +1,27 @@
+package ch.cyberduck.core;
+
+/*
+ * Copyright (c) 2002-2022 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+public interface ConnectionTimeout {
+    String PREFERENCE_KEY = "connection.timeout.seconds";
+
+    int getTimeout();
+
+    interface MutableConnectionTimeout extends ConnectionTimeout
+    {
+        void setTimeout(int timeout);
+    }
+}

--- a/core/src/main/java/ch/cyberduck/core/ConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/ConnectionTimeout.java
@@ -20,8 +20,5 @@ public interface ConnectionTimeout {
 
     int getTimeout();
 
-    interface MutableConnectionTimeout extends ConnectionTimeout
-    {
-        void setTimeout(int timeout);
-    }
+    void setTimeout(int timeout);
 }

--- a/core/src/main/java/ch/cyberduck/core/ConnectionTimeoutFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/ConnectionTimeoutFactory.java
@@ -1,0 +1,68 @@
+package ch.cyberduck.core;
+
+/*
+ * Copyright (c) 2002-2022 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+import ch.cyberduck.core.preferences.HostPreferences;
+import ch.cyberduck.core.preferences.PreferencesReader;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class ConnectionTimeoutFactory extends Factory<ConnectionTimeout.MutableConnectionTimeout> {
+    private static final Logger log = LogManager.getLogger(ConnectionTimeoutFactory.class);
+
+    private final static ConnectionTimeoutFactory factory = new ConnectionTimeoutFactory();
+    private final ConnectionTimeout.MutableConnectionTimeout instance;
+
+    private final Constructor<? extends ConnectionTimeout> constructor;
+
+    private ConnectionTimeoutFactory() {
+        super("factory.connectiontimeout.class");
+        instance = create();
+
+        constructor = ConstructorUtils.getMatchingAccessibleConstructor(clazz, PreferencesReader.class);
+    }
+
+    public ConnectionTimeout create(final PreferencesReader preferences) {
+        ConnectionTimeout temp = instance;
+        if(constructor != null) {
+            try {
+                temp = constructor.newInstance(preferences);
+            }
+            catch(InstantiationException | InvocationTargetException | IllegalAccessException e) {
+                log.error(String.format("Failure loading host connection timeout class %s. %s", clazz, e.getMessage()));
+            }
+        }
+        return temp;
+    }
+
+    public static ConnectionTimeout.MutableConnectionTimeout get() {
+        return factory.instance;
+    }
+
+    public static ConnectionTimeout get(final Host host) {
+        return get(new HostPreferences(host));
+    }
+
+    public static ConnectionTimeout get(final PreferencesReader preferences) {
+        return factory.create(preferences);
+    }
+}

--- a/core/src/main/java/ch/cyberduck/core/ConnectionTimeoutFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/ConnectionTimeoutFactory.java
@@ -26,11 +26,11 @@ import org.apache.logging.log4j.Logger;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-public class ConnectionTimeoutFactory extends Factory<ConnectionTimeout.MutableConnectionTimeout> {
+public class ConnectionTimeoutFactory extends Factory<ConnectionTimeout> {
     private static final Logger log = LogManager.getLogger(ConnectionTimeoutFactory.class);
 
-    private final static ConnectionTimeoutFactory factory = new ConnectionTimeoutFactory();
-    private final ConnectionTimeout.MutableConnectionTimeout instance;
+    private static final ConnectionTimeoutFactory factory = new ConnectionTimeoutFactory();
+    private final ConnectionTimeout instance;
 
     private final Constructor<? extends ConnectionTimeout> constructor;
 
@@ -54,7 +54,7 @@ public class ConnectionTimeoutFactory extends Factory<ConnectionTimeout.MutableC
         return temp;
     }
 
-    public static ConnectionTimeout.MutableConnectionTimeout get() {
+    public static ConnectionTimeout get() {
         return factory.instance;
     }
 

--- a/core/src/main/java/ch/cyberduck/core/DefaultConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/DefaultConnectionTimeout.java
@@ -23,23 +23,21 @@ import ch.cyberduck.core.preferences.PreferencesReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class DefaultConnectionTimeout implements ConnectionTimeout.MutableConnectionTimeout {
+public class DefaultConnectionTimeout implements ConnectionTimeout {
     private static final Logger log = LogManager.getLogger(DefaultConnectionTimeout.class);
+    private static final Preferences mutablePreferences = PreferencesFactory.get();
 
     public final static int TIMEOUT_MIN = 10;
     public final static int TIMEOUT_MAX = 60;
 
-    private final Preferences mutablePreferences;
     private final PreferencesReader preferences;
 
     public DefaultConnectionTimeout() {
-        mutablePreferences = PreferencesFactory.get();
-        preferences = mutablePreferences;
+        this(mutablePreferences);
     }
 
     public DefaultConnectionTimeout(final PreferencesReader preferences) {
         this.preferences = preferences;
-        mutablePreferences = null;
     }
 
     @Override
@@ -49,10 +47,6 @@ public class DefaultConnectionTimeout implements ConnectionTimeout.MutableConnec
 
     @Override
     public void setTimeout(final int timeout) {
-        if(mutablePreferences == null) {
-            log.warn(String.format("Trying to set %s to %d on Host preferences.", PREFERENCE_KEY, timeout));
-            return;
-        }
         mutablePreferences.setProperty(PREFERENCE_KEY, clamp(timeout));
     }
 

--- a/core/src/main/java/ch/cyberduck/core/DefaultConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/DefaultConnectionTimeout.java
@@ -1,0 +1,68 @@
+package ch.cyberduck.core;
+
+/*
+ * Copyright (c) 2002-2022 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.preferences.HostPreferences;
+import ch.cyberduck.core.preferences.Preferences;
+import ch.cyberduck.core.preferences.PreferencesFactory;
+import ch.cyberduck.core.preferences.PreferencesReader;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DefaultConnectionTimeout implements ConnectionTimeout.MutableConnectionTimeout {
+    private static final Logger log = LogManager.getLogger(DefaultConnectionTimeout.class);
+
+    public final static int TIMEOUT_MIN = 10;
+    public final static int TIMEOUT_MAX = 60;
+
+    private final Preferences mutablePreferences;
+    private final PreferencesReader preferences;
+
+    public DefaultConnectionTimeout() {
+        mutablePreferences = PreferencesFactory.get();
+        preferences = mutablePreferences;
+    }
+
+    public DefaultConnectionTimeout(final PreferencesReader preferences) {
+        this.preferences = preferences;
+        mutablePreferences = null;
+    }
+
+    @Override
+    public int getTimeout() {
+        return clamp(preferences.getInteger(PREFERENCE_KEY));
+    }
+
+    @Override
+    public void setTimeout(final int timeout) {
+        if(mutablePreferences == null) {
+            log.warn(String.format("Trying to set %s to %d on Host preferences.", PREFERENCE_KEY, timeout));
+            return;
+        }
+        mutablePreferences.setProperty(PREFERENCE_KEY, clamp(timeout));
+    }
+
+    private static int clamp(int value) {
+        if(value < TIMEOUT_MIN) {
+            value = TIMEOUT_MIN;
+        }
+        if(value > TIMEOUT_MAX) {
+            value = TIMEOUT_MAX;
+        }
+        return value;
+    }
+}

--- a/core/src/main/java/ch/cyberduck/core/DisabledConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/DisabledConnectionTimeout.java
@@ -1,0 +1,41 @@
+package ch.cyberduck.core;
+
+/*
+ * Copyright (c) 2002-2022 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.preferences.PreferencesFactory;
+import ch.cyberduck.core.preferences.PreferencesReader;
+
+public class DisabledConnectionTimeout implements ConnectionTimeout.MutableConnectionTimeout {
+    private final PreferencesReader preferences;
+
+    public DisabledConnectionTimeout() {
+        this(PreferencesFactory.get());
+    }
+
+    public DisabledConnectionTimeout(final PreferencesReader preferences) {
+        this.preferences = preferences;
+    }
+
+    @Override
+    public int getTimeout() {
+        return preferences.getInteger(PREFERENCE_KEY);
+    }
+
+    @Override
+    public void setTimeout(final int timeout) {
+        // NOP
+    }
+}

--- a/core/src/main/java/ch/cyberduck/core/DisabledConnectionTimeout.java
+++ b/core/src/main/java/ch/cyberduck/core/DisabledConnectionTimeout.java
@@ -18,7 +18,7 @@ package ch.cyberduck.core;
 import ch.cyberduck.core.preferences.PreferencesFactory;
 import ch.cyberduck.core.preferences.PreferencesReader;
 
-public class DisabledConnectionTimeout implements ConnectionTimeout.MutableConnectionTimeout {
+public class DisabledConnectionTimeout implements ConnectionTimeout {
     private final PreferencesReader preferences;
 
     public DisabledConnectionTimeout() {

--- a/core/src/main/java/ch/cyberduck/core/diagnostics/DefaultInetAddressReachability.java
+++ b/core/src/main/java/ch/cyberduck/core/diagnostics/DefaultInetAddressReachability.java
@@ -17,6 +17,7 @@ package ch.cyberduck.core.diagnostics;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.preferences.Preferences;
 import ch.cyberduck.core.preferences.PreferencesFactory;
@@ -30,14 +31,11 @@ import java.net.InetAddress;
  */
 public class DefaultInetAddressReachability extends DisabledReachability {
 
-    private final Preferences preferences
-        = PreferencesFactory.get();
-
     @Override
     public boolean isReachable(final Host host) {
         try {
             return InetAddress.getByName(host.getHostname()).isReachable(
-                preferences.getInteger("connection.timeout.seconds") * 1000
+                    ConnectionTimeoutFactory.get().getTimeout() * 1000
             );
         }
         catch(IOException e) {

--- a/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
+++ b/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
@@ -17,6 +17,7 @@ package ch.cyberduck.core.http;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.LoginCallback;
 import ch.cyberduck.core.PreferencesUseragentProvider;
@@ -142,7 +143,7 @@ public class HttpConnectionPoolBuilder {
                 break;
         }
         configuration.setUserAgent(new PreferencesUseragentProvider().get());
-        final int timeout = new HostPreferences(host).getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(host).getTimeout() * 1000;
         configuration.setDefaultSocketConfig(SocketConfig.custom()
             .setTcpNoDelay(true)
             .setSoTimeout(timeout)

--- a/core/src/main/java/ch/cyberduck/core/preferences/Preferences.java
+++ b/core/src/main/java/ch/cyberduck/core/preferences/Preferences.java
@@ -1383,6 +1383,7 @@ public abstract class Preferences implements Locales, PreferencesReader {
         this.setDefault("factory.securerandom.class", DefaultSecureRandomProvider.class.getName());
         this.setDefault("factory.providerhelpservice.class", DefaultProviderHelpService.class.getName());
         this.setDefault("factory.quicklook.class", ApplicationLauncherQuicklook.class.getName());
+        this.setDefault("factory.connectiontimeout.class", DefaultConnectionTimeout.class.getName());
     }
 
     /**

--- a/core/src/main/java/ch/cyberduck/core/socket/DefaultSocketConfigurator.java
+++ b/core/src/main/java/ch/cyberduck/core/socket/DefaultSocketConfigurator.java
@@ -17,6 +17,7 @@ package ch.cyberduck.core.socket;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.preferences.Preferences;
 import ch.cyberduck.core.preferences.PreferencesFactory;
 
@@ -40,7 +41,7 @@ public class DefaultSocketConfigurator implements SocketConfigurator {
         if(preferences.getInteger("connection.buffer.send") > 0) {
             socket.setSendBufferSize(preferences.getInteger("connection.buffer.send"));
         }
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         if(log.isInfoEnabled()) {
             log.info(String.format("Set timeout to %dms for socket %s", timeout, socket));
         }

--- a/dracoon/src/main/java/ch/cyberduck/core/sds/SDSSession.java
+++ b/dracoon/src/main/java/ch/cyberduck/core/sds/SDSSession.java
@@ -256,7 +256,7 @@ public class SDSSession extends HttpSession<SDSApiClient> {
                 .register(new JSON())
                 .register(JacksonFeature.class)
                 .connectorProvider(new HttpComponentsProvider(apache))));
-        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(preferences).getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setReadTimeout(timeout);
         client.setUserAgent(new PreferencesUseragentProvider().get());

--- a/dracoon/src/main/java/ch/cyberduck/core/sds/SDSSession.java
+++ b/dracoon/src/main/java/ch/cyberduck/core/sds/SDSSession.java
@@ -256,7 +256,7 @@ public class SDSSession extends HttpSession<SDSApiClient> {
                 .register(new JSON())
                 .register(JacksonFeature.class)
                 .connectorProvider(new HttpComponentsProvider(apache))));
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setReadTimeout(timeout);
         client.setUserAgent(new PreferencesUseragentProvider().get());

--- a/eue/src/main/java/ch/cyberduck/core/eue/EueApiClient.java
+++ b/eue/src/main/java/ch/cyberduck/core/eue/EueApiClient.java
@@ -1,5 +1,6 @@
 package ch.cyberduck.core.eue;
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.PreferencesUseragentProvider;
 import ch.cyberduck.core.eue.io.swagger.client.ApiClient;
 import ch.cyberduck.core.eue.io.swagger.client.ApiException;
@@ -26,7 +27,7 @@ public class EueApiClient extends ApiClient {
 		this.setHttpClient(ClientBuilder.newClient(new ClientConfig().register(new InputStreamProvider())
 				.register(MultiPartFeature.class).register(new JSON()).register(JacksonFeature.class)
 				.connectorProvider(new HttpComponentsProvider(session.getClient()))));
-		final int timeout = new HostPreferences(session.getHost()).getInteger("connection.timeout.seconds") * 1000;
+		final int timeout = ConnectionTimeoutFactory.get(session.getHost()).getTimeout() * 1000;
 		this.setConnectTimeout(timeout);
 		this.setReadTimeout(timeout);
 		this.setUserAgent(new PreferencesUseragentProvider().get());

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSession.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSession.java
@@ -18,6 +18,7 @@ package ch.cyberduck.core.ftp;
  */
 
 import ch.cyberduck.core.ConnectionCallback;
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.HostKeyCallback;
 import ch.cyberduck.core.ListService;
@@ -139,7 +140,7 @@ public class FTPSession extends SSLSession<FTPClient> {
         client.setProtocol(host.getProtocol());
         client.setSocketFactory(new ProxySocketFactory(host));
         client.setControlEncoding(host.getEncoding());
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setDefaultTimeout(timeout);
         client.setDataTimeout(timeout);

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSession.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSession.java
@@ -140,7 +140,7 @@ public class FTPSession extends SSLSession<FTPClient> {
         client.setProtocol(host.getProtocol());
         client.setSocketFactory(new ProxySocketFactory(host));
         client.setControlEncoding(host.getEncoding());
-        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(preferences).getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setDefaultTimeout(timeout);
         client.setDataTimeout(timeout);

--- a/irods/src/main/java/ch/cyberduck/core/irods/IRODSSession.java
+++ b/irods/src/main/java/ch/cyberduck/core/irods/IRODSSession.java
@@ -18,6 +18,7 @@ package ch.cyberduck.core.irods;
  */
 
 import ch.cyberduck.core.BookmarkNameProvider;
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Credentials;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.HostKeyCallback;
@@ -99,7 +100,7 @@ public class IRODSSession extends SSLSession<IRODSFileSystemAO> {
         final SettableJargonProperties properties = new SettableJargonProperties(client.getJargonProperties());
         properties.setEncoding(host.getEncoding());
         final PreferencesReader preferences = new HostPreferences(host);
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(preferences).getTimeout() * 1000;
         properties.setIrodsSocketTimeout(timeout);
         properties.setIrodsParallelSocketTimeout(timeout);
         properties.setGetBufferSize(preferences.getInteger("connection.chunksize"));

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
@@ -86,7 +86,7 @@ public class PreferencesController extends ToolbarWindowController {
 
     private final Preferences preferences
         = PreferencesFactory.get();
-    private final ConnectionTimeout.MutableConnectionTimeout connectionTimeoutPreferences
+    private final ConnectionTimeout connectionTimeoutPreferences
             = ConnectionTimeoutFactory.get();
 
     private final ProfilesPreferencesController profilesPanelController;

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
@@ -86,6 +86,8 @@ public class PreferencesController extends ToolbarWindowController {
 
     private final Preferences preferences
         = PreferencesFactory.get();
+    private final ConnectionTimeout.MutableConnectionTimeout connectionTimeoutPreferences
+            = ConnectionTimeoutFactory.get();
 
     private final ProfilesPreferencesController profilesPanelController;
 
@@ -619,7 +621,7 @@ public class PreferencesController extends ToolbarWindowController {
 
     public void setConnectionTimeoutField(NSTextField b) {
         this.connectionTimeoutField = b;
-        this.connectionTimeoutField.setIntValue(preferences.getInteger("connection.timeout.seconds"));
+        this.connectionTimeoutField.setIntValue(connectionTimeoutPreferences.getTimeout());
     }
 
     @Outlet
@@ -629,13 +631,13 @@ public class PreferencesController extends ToolbarWindowController {
         this.connectionTimeoutStepper = b;
         this.connectionTimeoutStepper.setTarget(this.id());
         this.connectionTimeoutStepper.setAction(Foundation.selector("connectionTimeoutStepperClicked:"));
-        this.connectionTimeoutStepper.setIntValue(preferences.getInteger("connection.retry"));
+        this.connectionTimeoutStepper.setIntValue(connectionTimeoutPreferences.getTimeout());
     }
 
     @Action
     public void connectionTimeoutStepperClicked(final NSStepper sender) {
-        preferences.setProperty("connection.timeout.seconds", sender.intValue());
-        connectionTimeoutField.setIntValue(sender.intValue());
+        connectionTimeoutPreferences.setTimeout(sender.intValue());
+        connectionTimeoutField.setIntValue(connectionTimeoutPreferences.getTimeout());
     }
 
     @Outlet

--- a/s3/src/main/java/ch/cyberduck/core/aws/CustomClientConfiguration.java
+++ b/s3/src/main/java/ch/cyberduck/core/aws/CustomClientConfiguration.java
@@ -15,6 +15,7 @@ package ch.cyberduck.core.aws;
  * GNU General Public License for more details.
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.DisabledCancelCallback;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.PreferencesUseragentProvider;
@@ -60,7 +61,7 @@ public class CustomClientConfiguration extends ClientConfiguration {
                 }
             }
         });
-        final int timeout = new HostPreferences(host).getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(host).getTimeout() * 1000;
         this.setConnectionTimeout(timeout);
         this.setSocketTimeout(timeout);
         final UseragentProvider ua = new PreferencesUseragentProvider();

--- a/spectra/src/main/java/ch/cyberduck/core/spectra/SpectraClientBuilder.java
+++ b/spectra/src/main/java/ch/cyberduck/core/spectra/SpectraClientBuilder.java
@@ -14,6 +14,7 @@
 
 package ch.cyberduck.core.spectra;
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.PreferencesUseragentProvider;
 import ch.cyberduck.core.Scheme;
@@ -66,12 +67,12 @@ public class SpectraClientBuilder {
 
             @Override
             public int getConnectionTimeout() {
-                return new HostPreferences(bookmark).getInteger("connection.timeout.seconds") * 1000;
+                return ConnectionTimeoutFactory.get(bookmark).getTimeout() * 1000;
             }
 
             @Override
             public int getSocketTimeout() {
-                return new HostPreferences(bookmark).getInteger("connection.timeout.seconds") * 1000;
+                return ConnectionTimeoutFactory.get(bookmark).getTimeout() * 1000;
             }
 
             @Override

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -183,7 +183,7 @@ public class SFTPSession extends Session<SSHClient> {
 
     private SSHClient toClient(final HostKeyCallback key, final Config configuration) {
         final SSHClient connection = new SSHClient(configuration);
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(preferences).getTimeout() * 1000;
         connection.setTimeout(timeout);
         connection.setSocketFactory(new ProxySocketFactory(host));
         connection.addHostKeyVerifier(new HostKeyVerifier() {
@@ -261,7 +261,7 @@ public class SFTPSession extends Session<SSHClient> {
         this.authenticate(client, host, prompt, cancel);
         try {
             sftp = new LoggingSFTPEngine(client, this).init();
-            sftp.setTimeoutMs(preferences.getInteger("connection.timeout.seconds") * 1000);
+            sftp.setTimeoutMs(ConnectionTimeoutFactory.get(preferences).getTimeout() * 1000);
         }
         catch(IOException e) {
             throw new SFTPExceptionMappingService().map(e);

--- a/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateSession.java
+++ b/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateSession.java
@@ -15,6 +15,7 @@ package ch.cyberduck.core.storegate;
  * GNU General Public License for more details.
  */
 
+import ch.cyberduck.core.ConnectionTimeoutFactory;
 import ch.cyberduck.core.Credentials;
 import ch.cyberduck.core.DefaultIOExceptionMappingService;
 import ch.cyberduck.core.Host;
@@ -124,7 +125,7 @@ public class StoregateSession extends HttpSession<StoregateApiClient> {
             .register(new JSON())
             .register(JacksonFeature.class)
             .connectorProvider(new HttpComponentsProvider(apache))));
-        final int timeout = preferences.getInteger("connection.timeout.seconds") * 1000;
+        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setReadTimeout(timeout);
         client.setUserAgent(new PreferencesUseragentProvider().get());

--- a/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateSession.java
+++ b/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateSession.java
@@ -125,7 +125,7 @@ public class StoregateSession extends HttpSession<StoregateApiClient> {
             .register(new JSON())
             .register(JacksonFeature.class)
             .connectorProvider(new HttpComponentsProvider(apache))));
-        final int timeout = ConnectionTimeoutFactory.get().getTimeout() * 1000;
+        final int timeout = ConnectionTimeoutFactory.get(host).getTimeout() * 1000;
         client.setConnectTimeout(timeout);
         client.setReadTimeout(timeout);
         client.setUserAgent(new PreferencesUseragentProvider().get());

--- a/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
@@ -47,7 +47,7 @@ namespace Ch.Cyberduck.Ui.Controller
         private static readonly string ForFiles = LocaleFactory.localizedString("for Files", "Preferences");
         private static readonly string ForFolders = LocaleFactory.localizedString("for Folders", "Preferences");
         private static readonly Logger Log = LogManager.getLogger(typeof(PreferencesController).FullName);
-        private static ConnectionTimeout.MutableConnectionTimeout connectionTimeoutPreferences =
+        private static ConnectionTimeout connectionTimeoutPreferences =
             ConnectionTimeoutFactory.get();
         private static readonly KeyValueIconTriple<Host, string> NoneBookmark =
             new KeyValueIconTriple<Host, string>(null, LocaleFactory.localizedString("None"), null);

--- a/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
@@ -47,7 +47,8 @@ namespace Ch.Cyberduck.Ui.Controller
         private static readonly string ForFiles = LocaleFactory.localizedString("for Files", "Preferences");
         private static readonly string ForFolders = LocaleFactory.localizedString("for Folders", "Preferences");
         private static readonly Logger Log = LogManager.getLogger(typeof(PreferencesController).FullName);
-
+        private static ConnectionTimeout.MutableConnectionTimeout connectionTimeoutPreferences =
+            ConnectionTimeoutFactory.get();
         private static readonly KeyValueIconTriple<Host, string> NoneBookmark =
             new KeyValueIconTriple<Host, string>(null, LocaleFactory.localizedString("None"), null);
 
@@ -379,7 +380,7 @@ namespace Ch.Cyberduck.Ui.Controller
 
         private void View_ConnectionTimeoutChangedEvent()
         {
-            PreferencesFactory.get().setProperty("connection.timeout.seconds", View.ConnectionTimeout);
+            connectionTimeoutPreferences.setTimeout(View.ConnectionTimeout);
         }
 
         private void View_DefaultUploadThrottleChangedEvent()
@@ -1027,7 +1028,7 @@ namespace Ch.Cyberduck.Ui.Controller
             View.DefaultUploadThrottle = PreferencesFactory.get().getFloat("queue.upload.bandwidth.bytes");
             View.Retries = PreferencesFactory.get().getInteger("connection.retry");
             View.RetryDelay = PreferencesFactory.get().getInteger("connection.retry.delay");
-            View.ConnectionTimeout = PreferencesFactory.get().getInteger("connection.timeout.seconds");
+            View.ConnectionTimeout = connectionTimeoutPreferences.getTimeout();
             View.UseSystemProxy = PreferencesFactory.get().getBoolean("connection.proxy.enable");
             View.DebugLog = Level.DEBUG.equals(LoggerContext.getContext(false).getConfiguration().getRootLogger().getLevel()) ? true : false;
 


### PR DESCRIPTION
Cannot set no maximum, cannot set no minimum, but throws ArgumentOutOfRange if value is outside [Min,Max]
This forces connection.timeout.seconds to be within [Min,Max] on load of default.properties, potentially ignoring user-defined values outside of range in default.properties.