### PR TITLE
Add profile for ArvanCloud ir-thr-at1(Tehran)

### DIFF
--- a/profiles/ArvanCloud-S3(ir-thr-at1).cyberduckprofile
+++ b/profiles/ArvanCloud-S3(ir-thr-at1).cyberduckprofile
@@ -20,5 +20,15 @@
         <string>Access Key</string>
         <key>Password Placeholder</key>
         <string>Secret Key</string>
+        <key>Region</key>
+            <string>default</string>
+        <key>Regions</key>
+        <array>
+            <string>default</string>
+        </array>
+        <key>Properties</key>
+        <array>
+            <string>s3.storage.class.options=STANDARD</string>
+        </array>
     </dict>
 </plist>

--- a/profiles/ArvanCloud-S3(ir-thr-at1).cyberduckprofile
+++ b/profiles/ArvanCloud-S3(ir-thr-at1).cyberduckprofile
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Protocol</key>
+        <string>s3</string>
+        <key>Vendor</key>
+        <string>arvancloud-ir-thr-at1</string>
+        <key>Description</key>
+        <string>ArvanCloud IR THR AT1(Tehran-Asiatech)</string>
+        <key>Default Hostname</key>
+        <string>s3.ir-thr-at1.arvanstorage.com</string>
+        <key>Hostname Configurable</key>
+        <false/>
+        <key>Default Port</key>
+        <string>443</string>
+        <key>Port Configurable</key>
+        <false/>
+        <key>Username Placeholder</key>
+        <string>Access Key</string>
+        <key>Password Placeholder</key>
+        <string>Secret Key</string>
+    </dict>
+</plist>


### PR DESCRIPTION
ArvanCloud Object Storage goes beyond the limited traditional file storage. It gives you access to backup and archived files and allows sharing. Files like profile image in the app, images sent by users or scanned documents can be stored securely and easily in our Object Storage service.