### PR TITLE
An empty response to MLSD is valid and indicates an empty folder.

### DIFF
--- a/ftp/src/main/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReader.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReader.java
@@ -1,19 +1,19 @@
 package ch.cyberduck.core.ftp.list;
 
-    /*
-     * Copyright (c) 2002-2017 iterate GmbH. All rights reserved.
-     * https://cyberduck.io/
-     *
-     * This program is free software; you can redistribute it and/or modify
-     * it under the terms of the GNU General Public License as published by
-     * the Free Software Foundation, either version 3 of the License, or
-     * (at your option) any later version.
-     *
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU General Public License for more details.
-     */
+/*
+ * Copyright (c) 2002-2017 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 
 import ch.cyberduck.core.AttributedList;
 import ch.cyberduck.core.ListProgressListener;
@@ -48,6 +48,9 @@ public class FTPMlsdListResponseReader implements FTPDataResponseReader {
     @Override
     public AttributedList<Path> read(final Path directory, final List<String> replies, final ListProgressListener listener) throws FTPInvalidListException {
         final AttributedList<Path> children = new AttributedList<>();
+        if(replies.isEmpty()) {
+            return children;
+        }
         // At least one entry successfully parsed
         boolean success = false;
         for(String line : replies) {

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReaderTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReaderTest.java
@@ -129,6 +129,17 @@ public class FTPMlsdListResponseReaderTest {
     }
 
     @Test
+    public void testEmptyDir() throws Exception {
+        Path path = new Path(
+            "/www", EnumSet.of(Path.Type.directory));
+
+        String[] replies = new String[]{};
+
+        final AttributedList<Path> children = new FTPMlsdListResponseReader().read(path, Arrays.asList(replies), new DisabledListProgressListener());
+        assertEquals(0, children.size());
+    }
+
+    @Test
     public void testSize() throws Exception {
         Path path = new Path(
             "/www", EnumSet.of(Path.Type.directory));


### PR DESCRIPTION
Fix #13294.