### PR TITLE
Add profile for Yandex Object Storage

### DIFF
--- a/profiles/Yandex S3.cyberduckprofile
+++ b/profiles/Yandex S3.cyberduckprofile
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Protocol</key>
+        <string>s3</string>
+        <key>Vendor</key>
+        <string>yandex</string>
+        <key>Description</key>
+        <string>Yandex S3</string>
+        <key>Scheme</key>
+        <string>https</string>
+        <key>Default Port</key>
+        <string>443</string>
+        <key>Default Hostname</key>
+        <string>storage.yandexcloud.net</string>
+        <key>Hostname Configurable</key>
+        <false/>
+        <key>Port Configurable</key>
+        <false/>
+    </dict>
+</plist>


### PR DESCRIPTION
Yandex Object Storage is a universal, scalable solution for data storage. It is the perfect choice both for high-load services that require reliable and fast access to data, and for projects with minimal requirements for storage infrastructure.

It also has a [wiki page](https://cloud.yandex.com/en/docs/storage/tools/cyberduck) for cyberduck.
It will be much more convenient if cyberduck has a profile for it.