### PR TITLE
Fix #13367. Disable conflicting temporary file upload for rename and …

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/transfer/TransferStatus.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/TransferStatus.java
@@ -414,23 +414,13 @@ public class TransferStatus implements StreamCancelation, StreamProgress {
         return displayname;
     }
 
-    public TransferStatus rename(final Path renamed) {
-        this.rename.remote = renamed;
+    public TransferStatus withRename(final Path renamed) {
+        this.rename.withRemote(renamed);
         return this;
     }
 
-    /**
-     * @param temporary Temporary file to open output stream to
-     * @param finalname Target name
-     */
-    public TransferStatus temporary(final Path temporary, final Path finalname) {
-        this.rename.remote = temporary;
-        this.displayname.remote = finalname;
-        return this;
-    }
-
-    public TransferStatus rename(final Local renamed) {
-        this.rename.local = renamed;
+    public TransferStatus withRename(final Local renamed) {
+        this.rename.withLocal(renamed);
         return this;
     }
 
@@ -438,7 +428,12 @@ public class TransferStatus implements StreamCancelation, StreamProgress {
      * @param finalname Target filename to rename temporary file to
      */
     public TransferStatus withDisplayname(final Local finalname) {
-        this.displayname.local = finalname;
+        this.displayname.withLocal(finalname);
+        return this;
+    }
+
+    public TransferStatus withDisplayname(final Path finalname) {
+        this.displayname.withRemote(finalname);
         return this;
     }
 
@@ -735,6 +730,25 @@ public class TransferStatus implements StreamCancelation, StreamProgress {
          * Target filename is temporary and file should be renamed to display name when transfer is complete
          */
         public Local local;
+        /**
+         * Target exists
+         */
+        public boolean exists;
+
+        public Displayname withRemote(final Path remote) {
+            this.remote = remote;
+            return this;
+        }
+
+        public Displayname withLocal(final Local local) {
+            this.local = local;
+            return this;
+        }
+
+        public Displayname exists(final boolean exists) {
+            this.exists = exists;
+            return this;
+        }
 
         @Override
         public String toString() {
@@ -757,6 +771,16 @@ public class TransferStatus implements StreamCancelation, StreamProgress {
          * Renamed local target
          */
         public Local local;
+
+        public Rename withRemote(final Path remote) {
+            this.remote = remote;
+            return this;
+        }
+
+        public Rename withLocal(final Local local) {
+            this.local = local;
+            return this;
+        }
 
         @Override
         public String toString() {

--- a/core/src/main/java/ch/cyberduck/core/transfer/download/AbstractDownloadFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/download/AbstractDownloadFilter.java
@@ -230,7 +230,7 @@ public abstract class AbstractDownloadFilter implements TransferPathFilter {
                                 .append(true) // Read with offset
                                 .withOffset(offset)
                                 .withLength(length)
-                                .rename(segmentFile);
+                                .withRename(segmentFile);
                             if(log.isDebugEnabled()) {
                                 log.debug(String.format("Adding status %s for segment %s", segmentStatus, segmentFile));
                             }

--- a/core/src/main/java/ch/cyberduck/core/transfer/download/RenameFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/download/RenameFilter.java
@@ -54,12 +54,7 @@ public class RenameFilter extends AbstractDownloadFilter {
                 if(StringUtils.isNotBlank(Path.getExtension(filename))) {
                     proposal += String.format(".%s", Path.getExtension(filename));
                 }
-                if(parent.getRename().local != null) {
-                    status.rename(LocalFactory.get(parent.getRename().local, proposal));
-                }
-                else {
-                    status.rename(LocalFactory.get(local.getParent(), proposal));
-                }
+                status.withRename(LocalFactory.get(local.getParent(), proposal));
             }
             while(status.getRename().local.exists());
             if(log.isInfoEnabled()) {
@@ -72,7 +67,7 @@ public class RenameFilter extends AbstractDownloadFilter {
         }
         else {
             if(parent.getRename().local != null) {
-                status.rename(LocalFactory.get(parent.getRename().local, file.getName()));
+                status.withRename(LocalFactory.get(parent.getRename().local, file.getName()));
             }
             if(log.isInfoEnabled()) {
                 log.info(String.format("Changed download target from %s to %s", local, status.getRename().local));

--- a/core/src/main/java/ch/cyberduck/core/transfer/download/ResumeFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/download/ResumeFilter.java
@@ -111,7 +111,7 @@ public class ResumeFilter extends AbstractDownloadFilter {
                             status.setAppend(true);
                             status.setLength(status.getLength() - local.attributes().getSize());
                             status.setOffset(status.getOffset() + local.attributes().getSize());
-                            status.rename((Local) null);
+                            status.withRename((Local) null);
                             if(status.getLength() == 0L) {
                                 status.setComplete();
                             }

--- a/core/src/main/java/ch/cyberduck/core/transfer/upload/RenameExistingFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/upload/RenameExistingFilter.java
@@ -76,7 +76,7 @@ public class RenameExistingFilter extends AbstractUploadFilter {
             if(log.isDebugEnabled()) {
                 log.debug(String.format("Clear exist flag for file %s", file));
             }
-            status.setExists(false);
+            status.exists(false).getDisplayname().exists(false);
         }
         super.apply(file, local, status, listener);
     }

--- a/core/src/main/java/ch/cyberduck/core/transfer/upload/ResumeFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/upload/ResumeFilter.java
@@ -96,11 +96,9 @@ public class ResumeFilter extends AbstractUploadFilter {
                 final Write.Append append = upload.append(file, status);
                 if(append.append && append.size < status.getLength()) {
                     // Append to existing file
-                    status.setAppend(true);
+                    status.withRename((Path) null).withDisplayname((Path) null).setAppend(true);
                     status.setLength(status.getLength() - append.size);
                     status.setOffset(append.size);
-                    // Disable use of temporary target when resuming upload
-                    status.temporary(null, null);
                 }
             }
         }

--- a/core/src/test/java/ch/cyberduck/core/transfer/upload/OverwriteFilterTest.java
+++ b/core/src/test/java/ch/cyberduck/core/transfer/upload/OverwriteFilterTest.java
@@ -8,10 +8,12 @@ import ch.cyberduck.core.LocalAttributes;
 import ch.cyberduck.core.NullLocal;
 import ch.cyberduck.core.NullSession;
 import ch.cyberduck.core.Path;
+import ch.cyberduck.core.PathAttributes;
 import ch.cyberduck.core.Permission;
 import ch.cyberduck.core.TestProtocol;
 import ch.cyberduck.core.exception.AccessDeniedException;
 import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.AttributesFinder;
 import ch.cyberduck.core.features.Find;
 import ch.cyberduck.core.transfer.TransferStatus;
 import ch.cyberduck.core.transfer.symlink.DisabledUploadSymlinkResolver;
@@ -19,6 +21,7 @@ import ch.cyberduck.core.transfer.symlink.DisabledUploadSymlinkResolver;
 import org.junit.Test;
 
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 
@@ -104,7 +107,7 @@ public class OverwriteFilterTest {
     public void testPermissionsNoChange() throws Exception {
         final OverwriteFilter f = new OverwriteFilter(new DisabledUploadSymlinkResolver(), new NullSession(new Host(new TestProtocol())));
         final Path file = new Path("/t", EnumSet.of(Path.Type.file));
-        assertFalse(f.prepare(file, new NullLocal("t"), new TransferStatus(), new DisabledProgressListener()).isComplete());
+        assertFalse(f.prepare(file, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener()).isComplete());
         assertEquals(Acl.EMPTY, file.attributes().getAcl());
         assertEquals(Permission.EMPTY, file.attributes().getPermission());
     }
@@ -113,7 +116,7 @@ public class OverwriteFilterTest {
     public void testPermissionsExistsNoChange() throws Exception {
         final OverwriteFilter f = new OverwriteFilter(new DisabledUploadSymlinkResolver(), new NullSession(new Host(new TestProtocol())));
         final Path file = new Path("/t", EnumSet.of(Path.Type.file));
-        assertFalse(f.prepare(file, new NullLocal("/t"), new TransferStatus(), new DisabledProgressListener()).isComplete());
+        assertFalse(f.prepare(file, new NullLocal("/t"), new TransferStatus().exists(true), new DisabledProgressListener()).isComplete());
         assertEquals(Acl.EMPTY, file.attributes().getAcl());
         assertEquals(Permission.EMPTY, file.attributes().getPermission());
     }
@@ -124,11 +127,48 @@ public class OverwriteFilterTest {
         final OverwriteFilter f = new OverwriteFilter(new DisabledUploadSymlinkResolver(), new NullSession(host),
             new UploadFilterOptions(host).withTemporary(true));
         final Path file = new Path("/t", EnumSet.of(Path.Type.file));
-        final TransferStatus status = f.prepare(file, new NullLocal("t"), new TransferStatus(), new DisabledProgressListener());
-        assertNotNull(status.getRename());
-        assertNotEquals(file, status.getRename().remote);
-        assertNull(status.getRename().local);
+        final TransferStatus status = f.prepare(file, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
         assertNotNull(status.getRename().remote);
+        assertNotEquals(file, status.getRename().remote);
+        assertNotNull(status.getDisplayname().remote);
+        assertEquals(file, status.getDisplayname().remote);
+        assertFalse(status.getDisplayname().exists);
+    }
+
+    @Test
+    public void testTemporaryTargetExists() throws Exception {
+        final Host host = new Host(new TestProtocol());
+        final Path file = new Path("/t", EnumSet.of(Path.Type.file));
+        final AtomicBoolean found = new AtomicBoolean();
+        final AttributesFinder attributes = new AttributesFinder() {
+            @Override
+            public PathAttributes find(final Path file, final ListProgressListener listener) {
+                return new PathAttributes();
+            }
+        };
+        final Find find = new Find() {
+            @Override
+            public boolean find(final Path f, final ListProgressListener listener) {
+                if(f.equals(file)) {
+                    found.set(true);
+                    return true;
+                }
+                return false;
+            }
+        };
+        final OverwriteFilter f = new OverwriteFilter(new DisabledUploadSymlinkResolver(), new NullSession(host),
+            new UploadFilterOptions(host).withTemporary(true));
+        f.withFinder(find).withAttributes(attributes);
+        final TransferStatus status = f.prepare(file, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
+        assertTrue(found.get());
+        f.apply(file, new NullLocal("t"), status, new DisabledProgressListener());
+        assertNotNull(status.getRename().remote);
+        assertFalse(status.isExists());
+        assertNotNull(status.getDisplayname().remote);
+        assertNotEquals(file, status.getRename().remote);
+        // assertEquals(new Path("/t-2g3vYDqR-", EnumSet.of(Path.Type.file)), status.getRename().remote);
+        assertEquals(file, status.getDisplayname().remote);
+        assertTrue(status.getDisplayname().exists);
     }
 
     @Test(expected = AccessDeniedException.class)

--- a/core/src/test/java/ch/cyberduck/core/transfer/upload/RenameExistingFilterTest.java
+++ b/core/src/test/java/ch/cyberduck/core/transfer/upload/RenameExistingFilterTest.java
@@ -89,7 +89,7 @@ public class RenameExistingFilterTest {
     }
 
     @Test
-    public void testTemporaryFileUpload() throws Exception {
+    public void testFileUploadWithTemporaryFilename() throws Exception {
         final Path file = new Path("/t", EnumSet.of(Path.Type.file));
         final AtomicBoolean found = new AtomicBoolean();
         final AtomicInteger moved = new AtomicInteger();
@@ -163,9 +163,12 @@ public class RenameExistingFilterTest {
         f.withFinder(find).withAttributes(attributes);
         assertTrue(options.temporary);
         final TransferStatus status = f.prepare(file, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
+        f.apply(file, new NullLocal("t"), status, new DisabledProgressListener());
+        assertFalse(status.isExists());
+        assertFalse(status.getDisplayname().exists);
         assertNotNull(status.getRename());
         assertNotNull(status.getRename().remote);
-        assertNotEquals(file, status.getDisplayname().local);
+        assertEquals(file, status.getDisplayname().remote);
         assertNull(status.getRename().local);
         f.apply(file, new NullLocal("t"), status, new DisabledProgressListener());
         // Complete

--- a/core/src/test/java/ch/cyberduck/core/transfer/upload/RenameFilterTest.java
+++ b/core/src/test/java/ch/cyberduck/core/transfer/upload/RenameFilterTest.java
@@ -31,11 +31,49 @@ public class RenameFilterTest {
     }
 
     @Test
-    public void testDirectoryUpload() throws Exception {
+    public void testFileUploadWithTemporaryFilename() throws Exception {
+        final Path file = new Path("f", EnumSet.of(Path.Type.file));
+        final AtomicBoolean found = new AtomicBoolean();
+        final AttributesFinder attributes = new AttributesFinder() {
+            @Override
+            public PathAttributes find(final Path file, final ListProgressListener listener) {
+                return new PathAttributes();
+            }
+        };
+        final Find find = new Find() {
+            @Override
+            public boolean find(final Path f, final ListProgressListener listener) {
+                if(f.equals(file)) {
+                    found.set(true);
+                    return true;
+                }
+                return false;
+            }
+        };
+        final NullSession session = new NullSession(new Host(new TestProtocol()));
+        final RenameFilter f = new RenameFilter(new DisabledUploadSymlinkResolver(), session, new UploadFilterOptions(session.getHost()).withTemporary(true));
+        f.withFinder(find).withAttributes(attributes);
+        final TransferStatus status = f.prepare(file, new NullLocal("t/f"), new TransferStatus().exists(true), new DisabledProgressListener());
+        assertTrue(found.get());
+        assertFalse(status.isExists());
+        f.apply(file, new NullLocal("t/f"), status, new DisabledProgressListener());
+        assertNotNull(status.getDisplayname().remote);
+        assertNotEquals(file, status.getRename().remote);
+        assertFalse(status.isExists());
+        assertNotEquals(file, status.getDisplayname().remote);
+        assertFalse(status.getDisplayname().exists);
+        assertNull(status.getRename().local);
+        assertNotNull(status.getRename().remote);
+        // assertEquals(new Path("/f-2g3vYDqR-", EnumSet.of(Path.Type.file)), fileStatus.getRename().remote);
+        assertEquals(new Path("/f-1", EnumSet.of(Path.Type.file)), status.getDisplayname().remote);
+        assertNotEquals(status.getDisplayname().remote, status.getRename().remote);
+    }
+
+    @Test
+    public void testDirectoryUploadRename() throws Exception {
         final Path directory = new Path("/t", EnumSet.of(Path.Type.directory));
         final Path file = new Path(directory, "f", EnumSet.of(Path.Type.file));
         final AtomicBoolean found = new AtomicBoolean();
-        final AtomicBoolean moved = new AtomicBoolean();
         final AttributesFinder attributes = new AttributesFinder() {
             @Override
             public PathAttributes find(final Path file, final ListProgressListener listener) {
@@ -57,11 +95,20 @@ public class RenameFilterTest {
         f.withFinder(find).withAttributes(attributes);
         final TransferStatus directoryStatus = f.prepare(directory, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
         assertTrue(found.get());
+        assertFalse(directoryStatus.isExists());
+        f.apply(directory, new NullLocal("t"), directoryStatus, new DisabledProgressListener());
         assertNotNull(directoryStatus.getRename());
+        assertNotEquals(directory, directoryStatus.getRename().remote);
+        assertEquals(new Path("/t-1", EnumSet.of(Path.Type.directory)), directoryStatus.getRename().remote);
+        assertNull(directoryStatus.getDisplayname().remote);
         assertNull(directoryStatus.getRename().local);
         assertNotNull(directoryStatus.getRename().remote);
         final TransferStatus fileStatus = f.prepare(file, new NullLocal("t/f"), directoryStatus, new DisabledProgressListener());
+        f.apply(file, new NullLocal("t/f"), fileStatus, new DisabledProgressListener());
+        assertFalse(fileStatus.isExists());
         assertNotNull(fileStatus.getRename());
+        assertEquals(new Path(new Path("/t-1", EnumSet.of(Path.Type.directory)), "f", EnumSet.of(Path.Type.file)), fileStatus.getRename().remote);
+        assertNull(fileStatus.getDisplayname().remote);
         assertNull(fileStatus.getRename().local);
         assertNotNull(fileStatus.getRename().remote);
         assertEquals(new Path("/t-1/f", EnumSet.of(Path.Type.file)), fileStatus.getRename().remote);

--- a/core/src/test/java/ch/cyberduck/core/transfer/upload/ResumeFilterTest.java
+++ b/core/src/test/java/ch/cyberduck/core/transfer/upload/ResumeFilterTest.java
@@ -91,7 +91,7 @@ public class ResumeFilterTest {
     }
 
     @Test
-    public void testPrepareFalse() throws Exception {
+    public void testPrepareNoAppend() throws Exception {
         final Host host = new Host(new TestProtocol());
         final ResumeFilter f = new ResumeFilter(new DisabledUploadSymlinkResolver(), new NullSession(host),
             new UploadFilterOptions(host).withTemporary(true));
@@ -99,11 +99,13 @@ public class ResumeFilterTest {
         t.attributes().setSize(7L);
         final TransferStatus status = f.prepare(t, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
         assertFalse(status.isAppend());
+        assertFalse(status.isExists());
         assertNotNull(status.getRename().remote);
+        assertNotEquals(t, status.getRename().remote);
     }
 
     @Test
-    public void testPrepare() throws Exception {
+    public void testPrepareAppend() throws Exception {
         final Host host = new Host(new TestProtocol());
         final ResumeFilter f = new ResumeFilter(new DisabledUploadSymlinkResolver(), new NullSession(host) {
             @Override
@@ -131,22 +133,10 @@ public class ResumeFilterTest {
             }
         }, new TransferStatus().exists(true), new DisabledProgressListener());
         assertTrue(status.isAppend());
+        assertTrue(status.isExists());
         // Temporary target
         assertNull(status.getRename().remote);
         assertEquals(7L, status.getOffset());
-    }
-
-    @Test
-    public void testPrepare0() throws Exception {
-        final Host host = new Host(new TestProtocol());
-        final ResumeFilter f = new ResumeFilter(new DisabledUploadSymlinkResolver(), new NullSession(host),
-            new UploadFilterOptions(host).withTemporary(true));
-        final Path t = new Path("t", EnumSet.of(Path.Type.file));
-        t.attributes().setSize(0L);
-        final TransferStatus status = f.prepare(t, new NullLocal("t"), new TransferStatus().exists(true), new DisabledProgressListener());
-        assertFalse(status.isAppend());
-        assertNotNull(status.getRename().remote);
-        assertEquals(0L, status.getOffset());
     }
 
     @Test


### PR DESCRIPTION
…resume filters. Remember status of target file for later rename.