### PR TITLE
Revert "Update dependency."

### DIFF
--- a/dropbox/pom.xml
+++ b/dropbox/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dropbox</artifactId>
     <properties>
-        <dropbox-core-sdk-version>5.2.0</dropbox-core-sdk-version>
+        <dropbox-core-sdk-version>5.0.0</dropbox-core-sdk-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This reverts commit 8828edb526473ec062787c1aaea7c0557674c1a7.

Temporarily, until decided to either rebuild Dropbox SDK for JDK 1.8 or keep running on 5.0.