### PR TITLE
Fix AppX Build

### DIFF
--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -22,4 +22,8 @@
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.Props', $(BasePath)../))" />
 
+    <PropertyGroup Condition=" '$(BuildVersion)'!='' And '$(Revision)'!='' ">
+        <Version>$(BuildVersion).$(Revision)</Version>
+    </PropertyGroup>
+
 </Project>

--- a/windows/build.xml
+++ b/windows/build.xml
@@ -60,7 +60,7 @@
             <property name="BuildProjectReferences" value="false" />
             <property name="Configuration" value="${msbuild.configuration}" />
             <property name="Copyright" value="${copyright}" />
-            <property name="Version" value="${version}.${revision}" />
+            <property name="Version" value="${normalized.version}.${revision}" />
         </msbuild>
     </target>
 
@@ -91,7 +91,8 @@
             <property name="Copyright" value="${copyright}" />
             <property name="ShortVersion" value="${version} (${revision})" />
             <property name="SignOutput" value="${msbuild.sign}" />
-            <property name="Version" value="${normalized.version}.${revision}" />
+            <property name="BuildVersion" value="${normalized.version}" />
+            <property name="Revision" value="${revision}" />
         </msbuild>
     </target>
 

--- a/windows/src/main/appx/Cyberduck.Package.proj
+++ b/windows/src/main/appx/Cyberduck.Package.proj
@@ -18,6 +18,8 @@
     <PackageFiles>$(IntermediateOutputPath)$(PackageName)/PackageFiles/</PackageFiles>
     <VFS>$(PackageFiles)VFS/</VFS>
     <PackageLayout>$(PackageFiles)</PackageLayout>
+
+    <Version Condition=" '$(BuildVersion)'!='' ">$(BuildVersion).0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
Package acceptance validation error: Apps are not allowed to have a Version with a revision number other than zero specified in the app manifest. 