### PR TITLE
Statically register custom schemes for Google OAuth flow to workaroun…

### DIFF
--- a/setup/app/Info.plist
+++ b/setup/app/Info.plist
@@ -239,6 +239,16 @@
                     <string>irods</string>
                 </array>
             </dict>
+            <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Viewer</string>
+                <key>CFBundleURLName</key>
+                <string>Google OAuth Redirect</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>com.googleusercontent.apps.996125414232-30v0nuldk4p54spra0k6gg3b8c8c9kib</string>
+                </array>
+            </dict>
         </array>
         <key>CFBundleVersion</key>
         <string>${REVISION}</string>


### PR DESCRIPTION
…d issue when running in sandbox with Error Domain=NSCocoaErrorDomain Code=256 "The file couldn’t be opened." UserInfo={NSUnderlyingError=0x600003dee100 {Error Domain=NSOSStatusErrorDomain Code=-54 "permErr: permissions error (on file open)" UserInfo={_LSLine=1640, _LSFunction=_LSSetDefaultSchemeHandlerURLWaitingUntilDone}}}.