### PR TITLE
Revert "Bump google-api-client from 1.35.2 to 2.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
             <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
-                <version>2.0.0</version>
+                <version>1.35.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
This reverts commit e7a35bbc2105552b36e57a763d676e1c3c61e41e.