### PR TITLE
patch-MIME: Update core.mime.types

### DIFF
--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1493,6 +1493,7 @@ text/vnd.sun.j2me.app-descriptor		jad
 text/vnd.wap.wml				wml
 text/vnd.wap.wmlscript				wmls
 text/vtt					vtt
+text/x-ass					ass
 text/x-asm					s asm
 text/x-c					c cc cxx cpp h hh dic
 text/x-fortran					f for f77 f90

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1486,6 +1486,7 @@ text/vnd.sun.j2me.app-descriptor		jad
 # text/vnd.wap.sl
 text/vnd.wap.wml				wml
 text/vnd.wap.wmlscript				wmls
+text/vtt          vtt
 text/x-asm					s asm
 text/x-c					c cc cxx cpp h hh dic
 text/x-fortran					f for f77 f90

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1310,6 +1310,11 @@ chemical/x-cml					cml
 chemical/x-csml					csml
 # chemical/x-pdb
 chemical/x-xyz					xyz
+font/otf          otf
+font/sfnt         sfnt
+font/ttf          ttf
+font/woff         woff
+font/woff2        woff2
 image/bmp					bmp
 image/cgm					cgm
 # image/example

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -47,7 +47,7 @@ application/cdmi-queue				cdmiq
 application/cu-seeme				cu
 # application/cybercash
 application/davmount+xml			davmount
-application/dash+xml			mpd
+application/dash+xml				mpd
 # application/dca-rft
 # application/dec-dx
 # application/dialog-info+xml
@@ -152,7 +152,7 @@ application/mxf					mxf
 # application/nss
 # application/ocsp-request
 # application/ocsp-response
-application/octet-stream	bin dms lha lrf lzh so iso dmg dist distz pkg bpk dump elc deploy
+application/octet-stream			bin dms lha lrf lzh so iso dmg dist distz pkg bpk dump elc deploy
 application/oda					oda
 application/oebps-package+xml			opf
 application/ogg					ogx
@@ -1035,7 +1035,7 @@ application/x-cpio				cpio
 application/x-csh				csh
 application/x-debian-package			deb udeb
 application/x-dgc-compressed			dgc
-application/x-director			dir dcr dxr cst cct cxt w3d fgd swa
+application/x-director				dir dcr dxr cst cct cxt w3d fgd swa
 application/x-doom				wad
 application/x-dtbncx+xml			ncx
 application/x-dtbook+xml			dtb
@@ -1153,7 +1153,7 @@ application/zip					zip
 # audio/32kadpcm
 # audio/3gpp
 # audio/3gpp2
-audio/ac3           ac3
+audio/ac3           				ac3
 audio/adpcm					adp
 # audio/amr
 # audio/amr-wb
@@ -1175,7 +1175,7 @@ audio/basic					au snd
 # audio/dsr-es202212
 # audio/dv
 # audio/dvi4
-audio/eac3          eac3
+audio/eac3					eac3
 # audio/evrc
 # audio/evrc-qcp
 # audio/evrc0
@@ -1222,7 +1222,7 @@ audio/mpeg					mpga mp2 mp2a mp3 m2a m3a
 # audio/mpeg4-generic
 # audio/musepack
 audio/ogg					oga ogg spx
-audio/opus        opus
+audio/opus					opus
 # audio/parityfec
 # audio/pcma
 # audio/pcma-wb
@@ -1247,7 +1247,7 @@ audio/silk					sil
 # audio/tone
 # audio/uemclip
 # audio/ulpfec
-audio/usac        usac
+audio/usac					usac
 # audio/vdvi
 # audio/vmr-wb
 # audio/vnd.3gpp.iufp
@@ -1311,11 +1311,11 @@ chemical/x-cml					cml
 chemical/x-csml					csml
 # chemical/x-pdb
 chemical/x-xyz					xyz
-font/otf          otf
-font/sfnt         sfnt
-font/ttf          ttf
-font/woff         woff
-font/woff2        woff2
+font/otf					otf
+font/sfnt					sfnt
+font/ttf					ttf
+font/woff					woff
+font/woff2					woff2
 image/bmp					bmp
 image/cgm					cgm
 # image/example
@@ -1492,7 +1492,7 @@ text/vnd.sun.j2me.app-descriptor		jad
 # text/vnd.wap.sl
 text/vnd.wap.wml				wml
 text/vnd.wap.wmlscript				wmls
-text/vtt          vtt
+text/vtt					vtt
 text/x-asm					s asm
 text/x-c					c cc cxx cpp h hh dic
 text/x-fortran					f for f77 f90

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1153,7 +1153,7 @@ application/zip					zip
 # audio/32kadpcm
 # audio/3gpp
 # audio/3gpp2
-# audio/ac3
+audio/ac3           ac3
 audio/adpcm					adp
 # audio/amr
 # audio/amr-wb
@@ -1175,7 +1175,7 @@ audio/basic					au snd
 # audio/dsr-es202212
 # audio/dv
 # audio/dvi4
-# audio/eac3
+audio/eac3          eac3
 # audio/evrc
 # audio/evrc-qcp
 # audio/evrc0

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1247,6 +1247,7 @@ audio/silk					sil
 # audio/tone
 # audio/uemclip
 # audio/ulpfec
+audio/usac        usac
 # audio/vdvi
 # audio/vmr-wb
 # audio/vnd.3gpp.iufp

--- a/core/src/main/resources/core.mime.types
+++ b/core/src/main/resources/core.mime.types
@@ -1222,7 +1222,7 @@ audio/mpeg					mpga mp2 mp2a mp3 m2a m3a
 # audio/mpeg4-generic
 # audio/musepack
 audio/ogg					oga ogg spx
-# audio/opus
+audio/opus        opus
 # audio/parityfec
 # audio/pcma
 # audio/pcma-wb


### PR DESCRIPTION
ac3/eac3 are a fair bit more common for web use than dts, which already had multiple included and uncommented MIME types here. Added some other audio entries useful for CDN/streaming uploads, as well as some subtitle support via .vtt, .ass, and all RFC 4288 font/ types.
- Uncommented audio/opus, RFC 4288 lists .opus per RFC7587
- Added RFC 4288 MIME type for WebVTT/.vtt subtitles
- Added all RFC 4288 MIME types for fonts per RFC8081
- Added RFC 4288 MIME type for USAC aka xHE-AAC per [ISO-IEC_JTC1][Max_Neuendorf]
- Uncommented audio/ac3, RFC 4288 lists .ac3 per [RFC4184]
- Uncommented audio/eac3, RFC 4288 lists .eac3 per [RFC4598]
- Added [text/x-ass](https://reposcope.com/mimetype/text/x-ass) for Aegisub/Substation Alpha format subtitles