### PR TITLE
Do not fail uploads to non-standard storage integrations such as SFTP…

### DIFF
--- a/brick/src/main/java/ch/cyberduck/core/brick/BrickWriteFeature.java
+++ b/brick/src/main/java/ch/cyberduck/core/brick/BrickWriteFeature.java
@@ -101,7 +101,9 @@ public class BrickWriteFeature extends AbstractHttpWriteFeature<FileEntity> {
                                     return null;
                                 }
                                 else {
-                                    log.debug("No ETag header in response available");
+                                    if(log.isDebugEnabled()) {
+                                        log.debug("No ETag header in response available");
+                                    }
                                 }
                             default:
                                 EntityUtils.updateEntity(response, new BufferedHttpEntity(response.getEntity()));

--- a/brick/src/main/java/ch/cyberduck/core/brick/BrickWriteFeature.java
+++ b/brick/src/main/java/ch/cyberduck/core/brick/BrickWriteFeature.java
@@ -24,7 +24,6 @@ import ch.cyberduck.core.brick.io.swagger.client.model.FileEntity;
 import ch.cyberduck.core.brick.io.swagger.client.model.FileUploadPartEntity;
 import ch.cyberduck.core.exception.BackgroundException;
 import ch.cyberduck.core.exception.ChecksumException;
-import ch.cyberduck.core.exception.InteroperabilityException;
 import ch.cyberduck.core.http.AbstractHttpWriteFeature;
 import ch.cyberduck.core.http.DefaultHttpResponseExceptionMappingService;
 import ch.cyberduck.core.http.DelayedHttpEntityCallable;
@@ -95,20 +94,19 @@ public class BrickWriteFeature extends AbstractHttpWriteFeature<FileEntity> {
                                         final Checksum etag = Checksum.parse(StringUtils.remove(response.getFirstHeader("ETag").getValue(), '"'));
                                         if(!status.getChecksum().equals(etag)) {
                                             throw new ChecksumException(MessageFormat.format(LocaleFactory.localizedString("Upload {0} failed", "Error"), file.getName()),
-                                                MessageFormat.format("Mismatch between {0} hash {1} of uploaded data and ETag {2} returned by the server",
-                                                    etag.algorithm.toString(), status.getChecksum().hash, etag.hash));
+                                                    MessageFormat.format("Mismatch between {0} hash {1} of uploaded data and ETag {2} returned by the server",
+                                                            etag.algorithm.toString(), status.getChecksum().hash, etag.hash));
                                         }
                                     }
                                     return null;
                                 }
                                 else {
-                                    log.error(String.format("Missing ETag in response %s", response));
-                                    throw new InteroperabilityException(response.getStatusLine().getReasonPhrase());
+                                    log.debug("No ETag header in response available");
                                 }
                             default:
                                 EntityUtils.updateEntity(response, new BufferedHttpEntity(response.getEntity()));
                                 throw new DefaultHttpResponseExceptionMappingService().map(
-                                    new HttpResponseException(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()));
+                                        new HttpResponseException(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()));
                         }
                     }
                     finally {
@@ -148,7 +146,7 @@ public class BrickWriteFeature extends AbstractHttpWriteFeature<FileEntity> {
                     super.close();
                     try {
                         new BrickUploadFeature(session, BrickWriteFeature.this)
-                            .completeUpload(file, ref, status, Collections.singletonList(status));
+                                .completeUpload(file, ref, status, Collections.singletonList(status));
                     }
                     catch(BackgroundException e) {
                         throw new IOException(e.getMessage(), e);


### PR DESCRIPTION
… which don't send an ETag header field.