### PR TITLE
Review icon cache concurrency

### DIFF
--- a/core/native/refresh/src/main/csharp/Services/WpfIconProvider.cs
+++ b/core/native/refresh/src/main/csharp/Services/WpfIconProvider.cs
@@ -134,8 +134,11 @@ namespace Ch.Cyberduck.Core.Refresh.Services
 
         private BitmapSource Get(object key, string path, int size, string classifier, bool returnDefault)
         {
-            var images = Get(key, path, classifier, returnDefault, out var image);
-            return image ?? FindNearestFit(images, size, (c, s, i) => c.CacheIcon(key, s, i, classifier));
+            using (IconCache.UpgradeableReadLock())
+            {
+                var images = Get(key, path, classifier, returnDefault, out var image);
+                return image ?? FindNearestFit(images, size, (c, s, i) => c.CacheIcon(key, s, i, classifier));
+            }
         }
 
         private IEnumerable<BitmapSource> Get(object key, string path, string classifier, bool returnDefault, out BitmapSource @default)
@@ -146,19 +149,23 @@ namespace Ch.Cyberduck.Core.Refresh.Services
             {
                 bool isDefault = !IconCache.TryGetIcon<BitmapSource>(key, out _, classifier);
                 using Stream stream = GetStream(path);
-                images = GetImages(stream, (c, s) => c.TryGetIcon<BitmapSource>(key, s, out _, classifier), (c, s, i) =>
+                using (IconCache.WriteLock())
                 {
-                    if (isDefault)
+                    images = GetImages(stream, (c, s) => c.TryGetIcon<BitmapSource>(key, s, out _, classifier), (c, s, i) =>
                     {
-                        isDefault = false;
-                        if (returnDefault)
+                        if (isDefault)
                         {
-                            image = i;
+                            isDefault = false;
+                            if (returnDefault)
+                            {
+                                image = i;
+                            }
+                            IconCache.CacheIcon<BitmapSource>(key, s, classifier);
                         }
-                        IconCache.CacheIcon<BitmapSource>(key, s, classifier);
-                    }
-                    IconCache.CacheIcon(key, s, i, classifier);
-                });
+                        IconCache.CacheIcon(key, s, i, classifier);
+                    });
+
+                }
             }
             @default = image;
 

--- a/core/native/refresh/src/main/csharp/Services/WpfIconProvider.cs
+++ b/core/native/refresh/src/main/csharp/Services/WpfIconProvider.cs
@@ -147,10 +147,10 @@ namespace Ch.Cyberduck.Core.Refresh.Services
             var images = IconCache.Filter<BitmapSource>(((object key, string classifier, int) f) => Equals(key, f.key) && Equals(classifier, f.classifier));
             if (!images.Any())
             {
-                bool isDefault = !IconCache.TryGetIcon<BitmapSource>(key, out _, classifier);
-                using Stream stream = GetStream(path);
                 using (IconCache.WriteLock())
                 {
+                    bool isDefault = !IconCache.TryGetIcon<BitmapSource>(key, out _, classifier);
+                    using Stream stream = GetStream(path);
                     images = GetImages(stream, (c, s) => c.TryGetIcon<BitmapSource>(key, s, out _, classifier), (c, s, i) =>
                     {
                         if (isDefault)
@@ -164,7 +164,6 @@ namespace Ch.Cyberduck.Core.Refresh.Services
                         }
                         IconCache.CacheIcon(key, s, i, classifier);
                     });
-
                 }
             }
             @default = image;

--- a/core/native/refresh/src/main/csharp/System/Threading/ReaderWriterLockSlimExtensions.cs
+++ b/core/native/refresh/src/main/csharp/System/Threading/ReaderWriterLockSlimExtensions.cs
@@ -1,0 +1,50 @@
+﻿namespace System.Threading
+{
+    public static class ReaderWriterLockSlimExtensions
+    {
+        public static ReadLock UseReadLock(this ReaderWriterLockSlim @this) => new(@this);
+
+        public static UpgradeableReadLock UseUpgradeableReadLock(this ReaderWriterLockSlim @this) => new(@this);
+
+        public static WriteLock UseWriteLock(this ReaderWriterLockSlim @this) => new(@this);
+
+        public ref struct ReadLock
+        {
+            private readonly Action exit;
+
+            internal ReadLock(ReaderWriterLockSlim @this)
+            {
+                @this.EnterReadLock();
+                exit = @this.ExitReadLock;
+            }
+
+            public void Dispose() => exit?.Invoke();
+        }
+
+        public ref struct UpgradeableReadLock
+        {
+            private readonly Action exit;
+
+            internal UpgradeableReadLock(ReaderWriterLockSlim @this)
+            {
+                @this.EnterUpgradeableReadLock();
+                exit = @this.ExitUpgradeableReadLock;
+            }
+
+            public void Dispose() => exit?.Invoke();
+        }
+
+        public ref struct WriteLock
+        {
+            private readonly Action exit;
+
+            internal WriteLock(ReaderWriterLockSlim @this)
+            {
+                @this.EnterWriteLock();
+                exit = @this.ExitWriteLock;
+            }
+
+            public void Dispose() => exit?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
Enumerating over a dictionary may result in `System.InvalidOperationException` when other operations modify the IconCache in parallel, shouldn't happen, but apparently it does.

This changes the behavior to lock-early (the cache), and force synchronized access to the cache. Trying to minimize over-writing already existing caches (`GetCacheExclusive` in tandem with `GetCache`).
Populating non-cached elements creates a write-lock over the whole import process. In regular usage this shouldn't block, as access to the cache usually happens on the main-thread (exceptions may apply).

The underlying Hashtable for registering typed objects isn't affected by this at all - this can still be written to in parallel (don't see an issue here, as it is always direct indexer-access, no enumeration).