### PR TITLE
Add protocol predicates to filter parent references when loading connection profile

### DIFF
--- a/cli/src/test/java/ch/cyberduck/cli/CommandLinePathParserTest.java
+++ b/cli/src/test/java/ch/cyberduck/cli/CommandLinePathParserTest.java
@@ -85,7 +85,7 @@ public class CommandLinePathParserTest {
     @Test
     public void testParseProfile() throws Exception {
         final ProtocolFactory factory = new ProtocolFactory(new HashSet<>(Collections.singleton(new SwiftProtocol())));
-        final ProfilePlistReader reader = new ProfilePlistReader(factory, new DeserializerFactory());
+        final ProfilePlistReader reader = new ProfilePlistReader(factory);
         final Profile profile = reader.read(
             this.getClass().getResourceAsStream("/Rackspace US.cyberduckprofile")
         );

--- a/cli/src/test/java/ch/cyberduck/cli/TerminalHelpPrinterTest.java
+++ b/cli/src/test/java/ch/cyberduck/cli/TerminalHelpPrinterTest.java
@@ -17,7 +17,6 @@ package ch.cyberduck.cli;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
-import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Profile;
 import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.azure.AzureProtocol;
@@ -55,7 +54,7 @@ public class TerminalHelpPrinterTest {
     @Test
     public void testScheme() throws Exception {
         final ProtocolFactory factory = new ProtocolFactory(new HashSet<>(Collections.singleton(new AzureProtocol())));
-        final ProfilePlistReader reader = new ProfilePlistReader(factory, new DeserializerFactory());
+        final ProfilePlistReader reader = new ProfilePlistReader(factory);
         final Profile profile = reader.read(
             this.getClass().getResourceAsStream("/Azure.cyberduckprofile")
         );

--- a/core/dylib/src/main/java/ch/cyberduck/core/local/FinderLocal.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/local/FinderLocal.java
@@ -80,7 +80,7 @@ public class FinderLocal extends Local {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(this.getAbbreviatedPath(), "Path");
         dict.setStringForKey(this.getBookmark(), "Bookmark");
         return dict.getSerialized();

--- a/core/dylib/src/main/java/ch/cyberduck/core/serializer/impl/jna/PlistReader.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/serializer/impl/jna/PlistReader.java
@@ -18,49 +18,14 @@ package ch.cyberduck.core.serializer.impl.jna;
  * dkocher@cyberduck.ch
  */
 
-import ch.cyberduck.binding.foundation.NSArray;
 import ch.cyberduck.binding.foundation.NSDictionary;
-import ch.cyberduck.binding.foundation.NSEnumerator;
-import ch.cyberduck.binding.foundation.NSObject;
-import ch.cyberduck.core.Collection;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Serializable;
 import ch.cyberduck.core.exception.AccessDeniedException;
 import ch.cyberduck.core.exception.LocalAccessDeniedException;
 import ch.cyberduck.core.serializer.Reader;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.rococoa.Rococoa;
-
 public abstract class PlistReader<S extends Serializable> implements Reader<S> {
-    private static final Logger log = LogManager.getLogger(PlistReader.class);
-
-    @Override
-    public Collection<S> readCollection(final Local file) throws AccessDeniedException {
-        if(!file.exists()) {
-            throw new LocalAccessDeniedException(file.getAbsolute());
-        }
-        final Collection<S> c = new Collection<S>();
-        NSArray list = NSArray.arrayWithContentsOfFile(file.getAbsolute());
-        if(null == list) {
-            log.error(String.format("Invalid bookmark file %s", file));
-            return c;
-        }
-        final NSEnumerator i = list.objectEnumerator();
-        NSObject next;
-        while((next = i.nextObject()) != null) {
-            if(next.isKindOfClass(NSDictionary.CLASS)) {
-                final NSDictionary dict = Rococoa.cast(next, NSDictionary.class);
-                final S object = this.deserialize(dict);
-                if(null == object) {
-                    continue;
-                }
-                c.add(object);
-            }
-        }
-        return c;
-    }
 
     /**
      * @param file A valid bookmark dictionary

--- a/core/dylib/src/main/java/ch/cyberduck/core/serializer/impl/jna/PlistSerializer.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/serializer/impl/jna/PlistSerializer.java
@@ -27,7 +27,7 @@ import ch.cyberduck.core.serializer.Serializer;
 import java.util.Collection;
 import java.util.Map;
 
-public class PlistSerializer implements Serializer {
+public class PlistSerializer implements Serializer<NSDictionary> {
 
     final NSMutableDictionary dict;
 
@@ -46,14 +46,14 @@ public class PlistSerializer implements Serializer {
 
     @Override
     public void setObjectForKey(final Serializable value, final String key) {
-        dict.setObjectForKey(value.<NSDictionary>serialize(new PlistSerializer()), key);
+        dict.setObjectForKey(value.serialize(new PlistSerializer()), key);
     }
 
     @Override
-    public <T extends Serializable> void setListForKey(final Collection<T> value, final String key) {
+    public <O extends Serializable> void setListForKey(final Collection<O> value, final String key) {
         final NSMutableArray list = NSMutableArray.array();
         for(Serializable serializable : value) {
-            list.addObject(serializable.<NSDictionary>serialize(new PlistSerializer()));
+            list.addObject(serializable.serialize(new PlistSerializer()));
         }
         dict.setObjectForKey(list, key);
     }

--- a/core/src/main/java/ch/cyberduck/core/AbstractProtocol.java
+++ b/core/src/main/java/ch/cyberduck/core/AbstractProtocol.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public abstract class AbstractProtocol implements Protocol {
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         return null;
     }
 

--- a/core/src/main/java/ch/cyberduck/core/Acl.java
+++ b/core/src/main/java/ch/cyberduck/core/Acl.java
@@ -186,7 +186,7 @@ public final class Acl extends HashMap<Acl.User, Set<Acl.Role>> implements Seria
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         for(Entry<User, Set<Role>> entry : this.entrySet()) {
             final List<Role> roles = new ArrayList<>(entry.getValue());
             dict.setListForKey(roles, entry.getKey().getIdentifier());
@@ -540,25 +540,25 @@ public final class Acl extends HashMap<Acl.User, Set<Acl.Role>> implements Seria
         }
 
         @Override
-        public <T> T serialize(final Serializer dict) {
+        public <T> T serialize(final Serializer<T> dict) {
             dict.setStringForKey(name, "Name");
             return dict.getSerialized();
         }
     }
 
-    public static class RoleDictionary {
+    public static class RoleDictionary<T> {
 
-        private final DeserializerFactory deserializer;
+        private final DeserializerFactory<T> deserializer;
 
         public RoleDictionary() {
-            this.deserializer = new DeserializerFactory();
+            this.deserializer = new DeserializerFactory<>();
         }
 
-        public RoleDictionary(final DeserializerFactory deserializer) {
+        public RoleDictionary(final DeserializerFactory<T> deserializer) {
             this.deserializer = deserializer;
         }
 
-        public <T> Acl.Role deserialize(T serialized) {
+        public Acl.Role deserialize(T serialized) {
             final Deserializer dict = deserializer.create(serialized);
             return new Role(dict.stringForKey("Name"));
         }

--- a/core/src/main/java/ch/cyberduck/core/DeserializerFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/DeserializerFactory.java
@@ -25,19 +25,18 @@ import org.apache.commons.lang3.reflect.ConstructorUtils;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-public class DeserializerFactory<T, S extends Deserializer> extends Factory<S> {
+/**
+ * @param <T> Serialized object type
+ */
+public class DeserializerFactory<T> extends Factory<Deserializer<T>> {
 
     public DeserializerFactory() {
         super("factory.deserializer.class");
     }
 
-    public DeserializerFactory(final Class<S> impl) {
-        super(impl);
-    }
-
     public Deserializer<T> create(final T dict) {
         try {
-            final Constructor<? extends S> constructor = ConstructorUtils.getMatchingAccessibleConstructor(clazz, dict.getClass());
+            final Constructor<? extends Deserializer<T>> constructor = ConstructorUtils.getMatchingAccessibleConstructor(clazz, dict.getClass());
             return constructor.newInstance(dict);
         }
         catch(InstantiationException | IllegalAccessException | InvocationTargetException e) {
@@ -46,6 +45,6 @@ public class DeserializerFactory<T, S extends Deserializer> extends Factory<S> {
     }
 
     public static <T> Deserializer<T> get() {
-        return new DeserializerFactory<>().create();
+        return new DeserializerFactory<T>().create();
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/Host.java
+++ b/core/src/main/java/ch/cyberduck/core/Host.java
@@ -23,8 +23,6 @@ import ch.cyberduck.core.preferences.PreferencesFactory;
 import ch.cyberduck.core.serializer.Serializer;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Date;
@@ -34,7 +32,6 @@ import java.util.Set;
 import java.util.TimeZone;
 
 public class Host implements Serializable, Comparable<Host> {
-    private static final Logger log = LogManager.getLogger(Host.class);
 
     /**
      * The credentials to authenticate with for the CDN
@@ -88,13 +85,13 @@ public class Host implements Serializable, Comparable<Host> {
      * The connect mode to use if FTP
      */
     private FTPConnectMode connectMode
-        = FTPConnectMode.unknown;
+            = FTPConnectMode.unknown;
 
     /**
      * The maximum number of concurrent sessions to this host
      */
     private TransferType transfer
-        = TransferType.unknown;
+            = TransferType.unknown;
 
     /**
      * The custom download folder
@@ -238,7 +235,7 @@ public class Host implements Serializable, Comparable<Host> {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(protocol.getIdentifier(), "Protocol");
         if(StringUtils.isNotBlank(protocol.getProvider())) {
             if(!StringUtils.equals(protocol.getProvider(), protocol.getIdentifier())) {

--- a/core/src/main/java/ch/cyberduck/core/Local.java
+++ b/core/src/main/java/ch/cyberduck/core/Local.java
@@ -112,7 +112,7 @@ public class Local extends AbstractPath implements Referenceable, Serializable {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(path, "Path");
         return dict.getSerialized();
     }

--- a/core/src/main/java/ch/cyberduck/core/Path.java
+++ b/core/src/main/java/ch/cyberduck/core/Path.java
@@ -105,7 +105,7 @@ public class Path extends AbstractPath implements Referenceable, Serializable {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(String.valueOf(type), "Type");
         dict.setStringForKey(this.getAbsolute(), "Remote");
         if(symlink != null) {

--- a/core/src/main/java/ch/cyberduck/core/PathAttributes.java
+++ b/core/src/main/java/ch/cyberduck/core/PathAttributes.java
@@ -190,7 +190,7 @@ public class PathAttributes extends Attributes implements Serializable {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         if(size != -1) {
             dict.setStringForKey(String.valueOf(size), "Size");
         }

--- a/core/src/main/java/ch/cyberduck/core/Permission.java
+++ b/core/src/main/java/ch/cyberduck/core/Permission.java
@@ -145,7 +145,7 @@ public class Permission implements Serializable {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(this.getSymbol(), "Mask");
         return dict.getSerialized();
     }

--- a/core/src/main/java/ch/cyberduck/core/Profile.java
+++ b/core/src/main/java/ch/cyberduck/core/Profile.java
@@ -187,7 +187,7 @@ public class Profile implements Protocol {
     public boolean isBundled() {
         final String v = this.value("Bundled");
         if(StringUtils.isBlank(v)) {
-            return parent.isBundled();
+            return false;
         }
         return Boolean.parseBoolean(v);
     }

--- a/core/src/main/java/ch/cyberduck/core/Profile.java
+++ b/core/src/main/java/ch/cyberduck/core/Profile.java
@@ -21,7 +21,6 @@ package ch.cyberduck.core;
 
 import ch.cyberduck.core.exception.AccessDeniedException;
 import ch.cyberduck.core.features.Location;
-import ch.cyberduck.core.local.DefaultLocalTouchFeature;
 import ch.cyberduck.core.local.TemporaryFileServiceFactory;
 import ch.cyberduck.core.preferences.PreferencesFactory;
 import ch.cyberduck.core.serializer.Deserializer;
@@ -46,7 +45,7 @@ import java.util.stream.Collectors;
 public class Profile implements Protocol {
     private static final Logger log = LogManager.getLogger(Profile.class);
 
-    private final Deserializer<String> dict;
+    private final Deserializer<?> dict;
     /**
      * The actual protocol implementation registered
      */
@@ -55,7 +54,7 @@ public class Profile implements Protocol {
     private Local disk;
     private Local icon;
 
-    public Profile(final Protocol parent, final Deserializer<String> dict) {
+    public Profile(final Protocol parent, final Deserializer<?> dict) {
         this.parent = parent;
         this.dict = dict;
         this.disk = this.write(this.value("Disk"));
@@ -63,7 +62,7 @@ public class Profile implements Protocol {
     }
 
     @Override
-    public <T> T serialize(final Serializer serializer) {
+    public <T> T serialize(final Serializer<T> serializer) {
         for(String key : dict.keys()) {
             serializer.setStringForKey(dict.stringForKey(key), key);
         }

--- a/core/src/main/java/ch/cyberduck/core/ProtocolFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/ProtocolFactory.java
@@ -49,6 +49,12 @@ public final class ProtocolFactory {
 
     private final Preferences preferences = PreferencesFactory.get();
 
+    public static final Predicate<Protocol> PROTOCOL_PREDICATE
+            = protocol -> !protocol.isEnabled() && !protocol.isBundled();
+
+    public static final Predicate<Protocol> DEFAULT_PROFILE_PREDICATE
+            = protocol -> protocol.isEnabled() && protocol.isBundled();
+
     public static ProtocolFactory get() {
         return global;
     }
@@ -67,10 +73,10 @@ public final class ProtocolFactory {
      */
     public ProtocolFactory(final Set<Protocol> registered) {
         this(registered,
-            LocalFactory.get(ApplicationResourcesFinderFactory.get().find(),
-                PreferencesFactory.get().getProperty("profiles.folder.name")),
-            LocalFactory.get(SupportDirectoryFinderFactory.get().find(),
-                PreferencesFactory.get().getProperty("profiles.folder.name")));
+                LocalFactory.get(ApplicationResourcesFinderFactory.get().find(),
+                        PreferencesFactory.get().getProperty("profiles.folder.name")),
+                LocalFactory.get(SupportDirectoryFinderFactory.get().find(),
+                        PreferencesFactory.get().getProperty("profiles.folder.name")));
     }
 
     /**
@@ -96,9 +102,10 @@ public final class ProtocolFactory {
      * Load profiles embedded in bundles and installed in the application support directory.
      */
     public void load() {
-        this.load(new LocalProfilesFinder(this, bundle));
+        // Return default registered protocol specification as parent but not other profile
+        this.load(new LocalProfilesFinder(this, bundle, PROTOCOL_PREDICATE));
         // Load thirdparty protocols
-        this.load(new LocalProfilesFinder(this, profiles));
+        this.load(new LocalProfilesFinder(this, profiles, DEFAULT_PROFILE_PREDICATE));
     }
 
     /**
@@ -126,7 +133,7 @@ public final class ProtocolFactory {
      */
     public Local register(final Local file) {
         try {
-            final Profile profile = new ProfilePlistReader(this).read(file);
+            final Profile profile = new ProfilePlistReader(this, DEFAULT_PROFILE_PREDICATE).read(file);
             if(null == profile) {
                 log.error("Attempt to register unknown protocol");
                 return null;
@@ -209,23 +216,23 @@ public final class ProtocolFactory {
      */
     public Protocol forName(final List<Protocol> enabled, final String identifier, final String provider) {
         final Protocol match =
-            // Exact match with hash code
-            enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> String.valueOf(protocol.hashCode()).equals(identifier)).findFirst().orElse(
-                // Matching vendor string for third party profiles
-                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getIdentifier(), identifier) && StringUtils.equals(protocol.getProvider(), provider)).findFirst().orElse(
-                    // Matching vendor string usage in CLI
-                    enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getProvider(), identifier)).findFirst().orElse(
-                        // Fallback for bug in 6.1
-                        enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(String.format("%s-%s", protocol.getIdentifier(), protocol.getProvider()), identifier)).findFirst().orElse(
-                                // Matching bundled first with identifier match
-                                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> protocol.isBundled() && StringUtils.equals(protocol.getIdentifier(), identifier)).findFirst().orElse(
-                                        // Matching scheme with fallback to generic protocol type
-                                        this.forScheme(enabled, identifier, enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getType().name(), identifier)).findFirst().orElse(null))
+                // Exact match with hash code
+                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> String.valueOf(protocol.hashCode()).equals(identifier)).findFirst().orElse(
+                        // Matching vendor string for third party profiles
+                        enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getIdentifier(), identifier) && StringUtils.equals(protocol.getProvider(), provider)).findFirst().orElse(
+                                // Matching vendor string usage in CLI
+                                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getProvider(), identifier)).findFirst().orElse(
+                                        // Fallback for bug in 6.1
+                                        enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(String.format("%s-%s", protocol.getIdentifier(), protocol.getProvider()), identifier)).findFirst().orElse(
+                                                // Matching bundled first with identifier match
+                                                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> protocol.isBundled() && StringUtils.equals(protocol.getIdentifier(), identifier)).findFirst().orElse(
+                                                        // Matching scheme with fallback to generic protocol type
+                                                        this.forScheme(enabled, identifier, enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> StringUtils.equals(protocol.getType().name(), identifier)).findFirst().orElse(null))
+                                                )
+                                        )
                                 )
                         )
-                    )
-                )
-            );
+                );
         if(null == match) {
             if(enabled.isEmpty()) {
                 log.error(String.format("List of registered protocols in %s is empty", this));
@@ -266,7 +273,7 @@ public final class ProtocolFactory {
                 break;
         }
         return enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> Arrays.asList(protocol.getSchemes()).contains(filter)).findFirst().orElse(
-            enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> Arrays.asList(protocol.getSchemes()).contains(scheme)).findFirst().orElse(fallback)
+                enabled.stream().sorted(new DeprecatedProtocolComparator()).filter(protocol -> Arrays.asList(protocol.getSchemes()).contains(scheme)).findFirst().orElse(fallback)
         );
     }
 

--- a/core/src/main/java/ch/cyberduck/core/ProtocolFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/ProtocolFactory.java
@@ -49,10 +49,10 @@ public final class ProtocolFactory {
 
     private final Preferences preferences = PreferencesFactory.get();
 
-    public static final Predicate<Protocol> PROTOCOL_PREDICATE
+    public static final Predicate<Protocol> DEFAULT_PROTOCOL_PREDICATE
             = protocol -> !protocol.isEnabled() && !protocol.isBundled();
 
-    public static final Predicate<Protocol> DEFAULT_PROFILE_PREDICATE
+    public static final Predicate<Protocol> BUNDLED_PROFILE_PREDICATE
             = protocol -> protocol.isEnabled() && protocol.isBundled();
 
     public static ProtocolFactory get() {
@@ -103,9 +103,9 @@ public final class ProtocolFactory {
      */
     public void load() {
         // Return default registered protocol specification as parent but not other profile
-        this.load(new LocalProfilesFinder(this, bundle, PROTOCOL_PREDICATE));
+        this.load(new LocalProfilesFinder(this, bundle, DEFAULT_PROTOCOL_PREDICATE));
         // Load thirdparty protocols
-        this.load(new LocalProfilesFinder(this, profiles, DEFAULT_PROFILE_PREDICATE));
+        this.load(new LocalProfilesFinder(this, profiles, BUNDLED_PROFILE_PREDICATE));
     }
 
     /**
@@ -133,7 +133,7 @@ public final class ProtocolFactory {
      */
     public Local register(final Local file) {
         try {
-            final Profile profile = new ProfilePlistReader(this, DEFAULT_PROFILE_PREDICATE).read(file);
+            final Profile profile = new ProfilePlistReader(this, BUNDLED_PROFILE_PREDICATE).read(file);
             if(null == profile) {
                 log.error("Attempt to register unknown protocol");
                 return null;

--- a/core/src/main/java/ch/cyberduck/core/Serializable.java
+++ b/core/src/main/java/ch/cyberduck/core/Serializable.java
@@ -25,5 +25,5 @@ public interface Serializable {
     /**
      * @param dict @return Native dictionary format
      */
-    <T> T serialize(Serializer dict);
+    <T> T serialize(Serializer<T> dict);
 }

--- a/core/src/main/java/ch/cyberduck/core/SerializerFactory.java
+++ b/core/src/main/java/ch/cyberduck/core/SerializerFactory.java
@@ -20,17 +20,16 @@ package ch.cyberduck.core;
 
 import ch.cyberduck.core.serializer.Serializer;
 
-public class SerializerFactory<S extends Serializer> extends Factory<S> {
+/**
+ * @param <T> Serialized object type
+ */
+public class SerializerFactory<T> extends Factory<Serializer<T>> {
 
     public SerializerFactory() {
         super("factory.serializer.class");
     }
 
-    public SerializerFactory(final Class<S> impl) {
-        super(impl);
-    }
-
-    public static Serializer get() {
-        return new SerializerFactory<>().create();
+    public static <T> Serializer<T> get() {
+        return new SerializerFactory<T>().create();
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/profiles/LocalProfileDescription.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/LocalProfileDescription.java
@@ -16,6 +16,7 @@ package ch.cyberduck.core.profiles;
  */
 
 import ch.cyberduck.core.Local;
+import ch.cyberduck.core.Protocol;
 import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.exception.BackgroundException;
 import ch.cyberduck.core.io.Checksum;
@@ -26,16 +27,27 @@ import ch.cyberduck.core.transfer.TransferStatus;
 import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 
+import java.util.function.Predicate;
+
 public final class LocalProfileDescription extends ProfileDescription {
 
     private final Local file;
 
-    public LocalProfileDescription(final Local file) {
-        this(ProtocolFactory.get(), file);
+    /**
+     * @param protocols Registered protocols
+     * @param file      File on disk
+     */
+    public LocalProfileDescription(final ProtocolFactory protocols, final Local file) {
+        this(protocols, protocol -> true, file);
     }
 
-    public LocalProfileDescription(final ProtocolFactory protocols, final Local file) {
-        super(protocols,
+    /**
+     * @param protocols Registered protocols
+     * @param parent    Filter to apply for parent protocol reference in registered protocols
+     * @param file      File on disk
+     */
+    public LocalProfileDescription(final ProtocolFactory protocols, final Predicate<Protocol> parent, final Local file) {
+        super(protocols, parent,
                 new LazyInitializer<Checksum>() {
                     @Override
                     protected Checksum initialize() throws ConcurrentException {

--- a/core/src/main/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorker.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorker.java
@@ -64,7 +64,7 @@ public class ProfilesSynchronizeWorker extends Worker<Set<ProfileDescription>> {
     @Override
     public Set<ProfileDescription> initialize() {
         try {
-            return new LocalProfilesFinder(registry, directory).find();
+            return new LocalProfilesFinder(registry, directory, ProtocolFactory.BUNDLED_PROFILE_PREDICATE).find();
         }
         catch(BackgroundException e) {
             return Collections.emptySet();
@@ -75,7 +75,7 @@ public class ProfilesSynchronizeWorker extends Worker<Set<ProfileDescription>> {
     public Set<ProfileDescription> run(final Session<?> session) throws BackgroundException {
         final Set<ProfileDescription> returned = new HashSet<>();
         // Find all locally installed profiles
-        final Set<ProfileDescription> installed = new LocalProfilesFinder(registry, directory).find();
+        final Set<ProfileDescription> installed = new LocalProfilesFinder(registry, directory, ProtocolFactory.BUNDLED_PROFILE_PREDICATE).find();
         // Find all profiles from repository
         final Set<ProfileDescription> remote = new RemoteProfilesFinder(registry, session).find();
         final ProfileMatcher matcher = new ChecksumProfileMatcher(remote);

--- a/core/src/main/java/ch/cyberduck/core/profiles/RemoteProfileDescription.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/RemoteProfileDescription.java
@@ -25,12 +25,13 @@ import org.apache.commons.lang3.concurrent.LazyInitializer;
 public final class RemoteProfileDescription extends ProfileDescription {
     private final Path file;
 
-    public RemoteProfileDescription(final Path file, final LazyInitializer<Local> profile) {
-        this(ProtocolFactory.get(), file, profile);
-    }
-
+    /**
+     * @param protocols Registered protocols
+     * @param file      Connection profile
+     * @param profile   Read connection profile to file on local disk
+     */
     public RemoteProfileDescription(final ProtocolFactory protocols, final Path file, final LazyInitializer<Local> profile) {
-        super(protocols, new LazyInitializer<Checksum>() {
+        super(protocols, ProtocolFactory.BUNDLED_PROFILE_PREDICATE, new LazyInitializer<Checksum>() {
             @Override
             protected Checksum initialize() {
                 return file.attributes().getChecksum();

--- a/core/src/main/java/ch/cyberduck/core/serializer/AclDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/AclDictionary.java
@@ -20,19 +20,19 @@ import ch.cyberduck.core.DeserializerFactory;
 
 import java.util.List;
 
-public class AclDictionary {
+public class AclDictionary<T> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<T> deserializer;
 
     public AclDictionary() {
-        this.deserializer = new DeserializerFactory();
+        this.deserializer = new DeserializerFactory<>();
     }
 
-    public AclDictionary(final DeserializerFactory deserializer) {
+    public AclDictionary(final DeserializerFactory<T> deserializer) {
         this.deserializer = deserializer;
     }
 
-    public <T> Acl deserialize(T serialized) {
+    public Acl deserialize(T serialized) {
         final Deserializer<?> dict = deserializer.create(serialized);
         final Acl acl = new Acl();
         final List<String> keys = dict.keys();

--- a/core/src/main/java/ch/cyberduck/core/serializer/Deserializer.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/Deserializer.java
@@ -21,6 +21,9 @@ package ch.cyberduck.core.serializer;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @param <T> Serialized object type
+ */
 public interface Deserializer<T> {
 
     /**
@@ -38,6 +41,7 @@ public interface Deserializer<T> {
     /**
      * Find multiple values for key
      *
+     * @param <L> Type of serialized native objects in list
      * @param key Key name
      * @return List values for key
      */

--- a/core/src/main/java/ch/cyberduck/core/serializer/HostDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/HostDictionary.java
@@ -36,10 +36,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.TimeZone;
 
-public class HostDictionary {
+public class HostDictionary<T> {
     private static final Logger log = LogManager.getLogger(HostDictionary.class);
 
-    private final DeserializerFactory factory;
+    private final DeserializerFactory<T> factory;
     private final ProtocolFactory protocols;
 
     public HostDictionary() {
@@ -47,20 +47,20 @@ public class HostDictionary {
     }
 
     public HostDictionary(final ProtocolFactory protocols) {
-        this(protocols, new DeserializerFactory());
+        this(protocols, new DeserializerFactory<>());
     }
 
-    public HostDictionary(final DeserializerFactory factory) {
+    public HostDictionary(final DeserializerFactory<T> factory) {
         this(ProtocolFactory.get(), factory);
     }
 
-    public HostDictionary(final ProtocolFactory protocols, final DeserializerFactory factory) {
+    public HostDictionary(final ProtocolFactory protocols, final DeserializerFactory<T> factory) {
         this.protocols = protocols;
         this.factory = factory;
     }
 
-    public <T> Host deserialize(final T serialized) {
-        final Deserializer dict = factory.create(serialized);
+    public Host deserialize(final T serialized) {
+        final Deserializer<T> dict = factory.create(serialized);
         Object protocolObj = dict.stringForKey("Protocol");
         if(protocolObj == null) {
             log.warn(String.format("Missing protocol key in %s", dict));
@@ -98,9 +98,9 @@ public class HostDictionary {
             if(keyObjDeprecated != null) {
                 bookmark.getCredentials().setIdentity(LocalFactory.get(keyObjDeprecated));
             }
-            final Object keyObj = dict.objectForKey("Private Key File Dictionary");
+            final T keyObj = dict.objectForKey("Private Key File Dictionary");
             if(keyObj != null) {
-                bookmark.getCredentials().setIdentity(new LocalDictionary(factory).deserialize(keyObj));
+                bookmark.getCredentials().setIdentity(new LocalDictionary<>(factory).deserialize(keyObj));
             }
             final Object certObj = dict.stringForKey("Client Certificate");
             if(certObj != null) {
@@ -119,9 +119,9 @@ public class HostDictionary {
             if(workdirObjDeprecated != null) {
                 bookmark.setWorkdir(new Path(workdirObjDeprecated.toString(), EnumSet.of(Path.Type.directory)));
             }
-            final Object workdirObj = dict.objectForKey("Workdir Dictionary");
+            final T workdirObj = dict.objectForKey("Workdir Dictionary");
             if(workdirObj != null) {
-                bookmark.setWorkdir(new PathDictionary(factory).deserialize(workdirObj));
+                bookmark.setWorkdir(new PathDictionary<>(factory).deserialize(workdirObj));
             }
             final Object nicknameObj = dict.stringForKey("Nickname");
             if(nicknameObj != null) {
@@ -156,13 +156,13 @@ public class HostDictionary {
             if(downloadObjDeprecated != null) {
                 bookmark.setDownloadFolder(LocalFactory.get(downloadObjDeprecated.toString()));
             }
-            final Object downloadObj = dict.objectForKey("Download Folder Dictionary");
+            final T downloadObj = dict.objectForKey("Download Folder Dictionary");
             if(downloadObj != null) {
-                bookmark.setDownloadFolder(new LocalDictionary(factory).deserialize(downloadObj));
+                bookmark.setDownloadFolder(new LocalDictionary<>(factory).deserialize(downloadObj));
             }
-            final Object uploadObj = dict.objectForKey("Upload Folder Dictionary");
+            final T uploadObj = dict.objectForKey("Upload Folder Dictionary");
             if(uploadObj != null) {
-                bookmark.setUploadFolder(new LocalDictionary(factory).deserialize(uploadObj));
+                bookmark.setUploadFolder(new LocalDictionary<>(factory).deserialize(uploadObj));
             }
             final Object timezoneObj = dict.stringForKey("Timezone");
             if(timezoneObj != null) {

--- a/core/src/main/java/ch/cyberduck/core/serializer/LocalDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/LocalDictionary.java
@@ -24,23 +24,23 @@ import ch.cyberduck.core.LocalFactory;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class LocalDictionary {
+public class LocalDictionary<T> {
 
-    private final DeserializerFactory factory;
+    private final DeserializerFactory<T> factory;
 
     public LocalDictionary() {
-        this.factory = new DeserializerFactory();
+        this.factory = new DeserializerFactory<>();
     }
 
-    public LocalDictionary(final DeserializerFactory factory) {
+    public LocalDictionary(final DeserializerFactory<T> factory) {
         this.factory = factory;
     }
 
-    public <T> Local deserialize(T serialized) {
+    public Local deserialize(T serialized) {
         return this.deserialize(factory.create(serialized));
     }
 
-    public <T> Local deserialize(Deserializer<T> dict) {
+    public Local deserialize(final Deserializer<T> dict) {
         final String path = dict.stringForKey("Path");
         if(StringUtils.isBlank(path)) {
             return null;

--- a/core/src/main/java/ch/cyberduck/core/serializer/PathAttributesDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/PathAttributesDictionary.java
@@ -28,20 +28,20 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
-public class PathAttributesDictionary {
+public class PathAttributesDictionary<T> {
 
-    private final DeserializerFactory factory;
+    private final DeserializerFactory<T> factory;
 
     public PathAttributesDictionary() {
-        this.factory = new DeserializerFactory();
+        this.factory = new DeserializerFactory<>();
     }
 
-    public PathAttributesDictionary(final DeserializerFactory factory) {
+    public PathAttributesDictionary(final DeserializerFactory<T> factory) {
         this.factory = factory;
     }
 
-    public <T> PathAttributes deserialize(T serialized) {
-        final Deserializer dict = factory.create(serialized);
+    public PathAttributes deserialize(final T serialized) {
+        final Deserializer<T> dict = factory.create(serialized);
         final PathAttributes attributes = new PathAttributes();
         final String sizeObj = dict.stringForKey("Size");
         if(sizeObj != null) {
@@ -69,11 +69,11 @@ public class PathAttributesDictionary {
         }
         final Object permissionObj = dict.objectForKey("Permission");
         if(permissionObj != null) {
-            attributes.setPermission(new PermissionDictionary().deserialize(permissionObj));
+            attributes.setPermission(new PermissionDictionary<>().deserialize(permissionObj));
         }
         final Object aclObj = dict.objectForKey("Acl");
         if(aclObj != null) {
-            attributes.setAcl(new AclDictionary().deserialize(aclObj));
+            attributes.setAcl(new AclDictionary<>().deserialize(aclObj));
         }
         if(dict.mapForKey("Link") != null) {
             final Map<String, String> link = dict.mapForKey("Link");
@@ -106,9 +106,9 @@ public class PathAttributesDictionary {
         attributes.setMetadata(Collections.emptyMap());
         attributes.setRegion(dict.stringForKey("Region"));
         attributes.setStorageClass(dict.stringForKey("Storage Class"));
-        final Object vaultObj = dict.objectForKey("Vault");
+        final T vaultObj = dict.objectForKey("Vault");
         if(vaultObj != null) {
-            attributes.setVault(new PathDictionary(factory).deserialize(vaultObj));
+            attributes.setVault(new PathDictionary<>(factory).deserialize(vaultObj));
         }
         final Map<String, String> customObj = dict.mapForKey("Custom");
         if(customObj != null) {

--- a/core/src/main/java/ch/cyberduck/core/serializer/PathDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/PathDictionary.java
@@ -29,21 +29,21 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.EnumSet;
 
-public class PathDictionary {
+public class PathDictionary<T> {
     private static final Logger log = LogManager.getLogger(PathDictionary.class);
 
-    private final DeserializerFactory factory;
+    private final DeserializerFactory<T> factory;
 
     public PathDictionary() {
-        this.factory = new DeserializerFactory();
+        this.factory = new DeserializerFactory<>();
     }
 
-    public PathDictionary(final DeserializerFactory factory) {
+    public PathDictionary(final DeserializerFactory<T> factory) {
         this.factory = factory;
     }
 
-    public <T> Path deserialize(final T serialized) {
-        final Deserializer dict = factory.create(serialized);
+    public Path deserialize(final T serialized) {
+        final Deserializer<T> dict = factory.create(serialized);
         final EnumSet<Path.Type> type = EnumSet.noneOf(Path.Type.class);
         final String typeObj = dict.stringForKey("Type");
         if(typeObj != null) {
@@ -57,9 +57,9 @@ public class PathDictionary {
             }
         }
         final Path path;
-        final Object attributesObj = dict.objectForKey("Attributes");
+        final T attributesObj = dict.objectForKey("Attributes");
         if(attributesObj != null) {
-            final PathAttributes attributes = new PathAttributesDictionary(factory).deserialize(attributesObj);
+            final PathAttributes attributes = new PathAttributesDictionary<>(factory).deserialize(attributesObj);
             // Legacy
             final String legacyTypeObj = factory.create(attributesObj).stringForKey("Type");
             if(legacyTypeObj != null) {
@@ -95,9 +95,9 @@ public class PathDictionary {
             }
             path = new Path(absolute, type);
         }
-        final Object symlinkObj = dict.objectForKey("Symbolic Link");
+        final T symlinkObj = dict.objectForKey("Symbolic Link");
         if(symlinkObj != null) {
-            path.setSymlinkTarget(new PathDictionary(factory).deserialize(symlinkObj));
+            path.setSymlinkTarget(new PathDictionary<>(factory).deserialize(symlinkObj));
         }
         return path;
     }

--- a/core/src/main/java/ch/cyberduck/core/serializer/PermissionDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/PermissionDictionary.java
@@ -21,20 +21,20 @@ package ch.cyberduck.core.serializer;
 import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Permission;
 
-public class PermissionDictionary {
+public class PermissionDictionary<T> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<T> deserializer;
 
     public PermissionDictionary() {
-        this.deserializer = new DeserializerFactory();
+        this.deserializer = new DeserializerFactory<>();
     }
 
-    public PermissionDictionary(final DeserializerFactory deserializer) {
+    public PermissionDictionary(final DeserializerFactory<T> deserializer) {
         this.deserializer = deserializer;
     }
 
-    public <T> Permission deserialize(T serialized) {
-        final Deserializer dict = deserializer.create(serialized);
+    public Permission deserialize(T serialized) {
+        final Deserializer<T> dict = deserializer.create(serialized);
         return new Permission(dict.stringForKey("Mask"));
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/serializer/ProfileDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/ProfileDictionary.java
@@ -29,10 +29,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.function.Predicate;
 
-public class ProfileDictionary {
+/**
+ * @param <T> Serialized object type
+ */
+public class ProfileDictionary<T> {
     private static final Logger log = LogManager.getLogger(ProfileDictionary.class);
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<T> deserializer;
     private final ProtocolFactory protocols;
 
     public ProfileDictionary() {
@@ -40,20 +43,25 @@ public class ProfileDictionary {
     }
 
     public ProfileDictionary(final ProtocolFactory protocols) {
-        this(protocols, new DeserializerFactory());
+        this(protocols, new DeserializerFactory<>());
     }
 
-    public ProfileDictionary(final DeserializerFactory deserializer) {
+    public ProfileDictionary(final DeserializerFactory<T> deserializer) {
         this(ProtocolFactory.get(), deserializer);
     }
 
-    public ProfileDictionary(final ProtocolFactory protocols, final DeserializerFactory deserializer) {
+    public ProfileDictionary(final ProtocolFactory protocols, final DeserializerFactory<T> deserializer) {
         this.protocols = protocols;
         this.deserializer = deserializer;
     }
 
-    public Profile deserialize(Object serialized) {
-        final Deserializer<String> dict = deserializer.create(serialized);
+    /**
+     * @param serialized Serialized bookmark
+     * @param parent     Filter for parent protocol reference
+     * @return Null if deserialization fails
+     */
+    public Profile deserialize(final T serialized, final Predicate<Protocol> parent) {
+        final Deserializer<T> dict = deserializer.create(serialized);
         final String protocol = dict.stringForKey("Protocol");
         if(StringUtils.isNotBlank(protocol)) {
             final Protocol parent = protocols.forName(protocols.find(new Predicate<Protocol>() {

--- a/core/src/main/java/ch/cyberduck/core/serializer/ProfileDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/ProfileDictionary.java
@@ -64,18 +64,13 @@ public class ProfileDictionary<T> {
         final Deserializer<T> dict = deserializer.create(serialized);
         final String protocol = dict.stringForKey("Protocol");
         if(StringUtils.isNotBlank(protocol)) {
-            final Protocol parent = protocols.forName(protocols.find(new Predicate<Protocol>() {
-                @Override
-                public boolean test(final Protocol protocol) {
-                    // Return default registered protocol specification as parent but not other profile
-                    return !(protocol.isEnabled() || protocol.isBundled());
-                }
-            }), protocol, null);
-            if(null == parent) {
+            // Return default registered protocol specification as parent
+            final Protocol found = protocols.forName(protocols.find(parent), protocol, null);
+            if(null == found) {
                 log.error(String.format("Unknown protocol %s in profile", protocol));
                 return null;
             }
-            return new Profile(parent, dict);
+            return new Profile(found, dict);
         }
         log.error("Missing protocol in profile");
         return null;

--- a/core/src/main/java/ch/cyberduck/core/serializer/Reader.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/Reader.java
@@ -18,7 +18,6 @@ package ch.cyberduck.core.serializer;
  * dkocher@cyberduck.ch
  */
 
-import ch.cyberduck.core.Collection;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Serializable;
 import ch.cyberduck.core.exception.AccessDeniedException;
@@ -26,12 +25,6 @@ import ch.cyberduck.core.exception.AccessDeniedException;
 import java.io.InputStream;
 
 public interface Reader<S extends Serializable> {
-
-    /**
-     * @param file Serialized file
-     * @return Deserialized content
-     */
-    Collection<S> readCollection(Local file) throws AccessDeniedException;
 
     /**
      * Read the serialized item from the given file

--- a/core/src/main/java/ch/cyberduck/core/serializer/Serializer.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/Serializer.java
@@ -23,7 +23,10 @@ import ch.cyberduck.core.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
-public interface Serializer {
+/**
+ * @param <T> Serialized object type
+ */
+public interface Serializer<T> {
 
     /**
      * @param value Value for key
@@ -38,19 +41,18 @@ public interface Serializer {
     void setObjectForKey(Serializable value, String key);
 
     /**
+     * @param <O>   Type of serialized native object
      * @param value Value for key
      * @param key   Identifier for value to serialize
      */
-    <T extends Serializable> void setListForKey(Collection<T> value, String key);
+    <O extends Serializable> void setListForKey(Collection<O> value, String key);
 
     void setStringListForKey(Collection<String> value, String key);
 
     void setMapForKey(Map<String, String> value, String key);
 
     /**
-     * @param <T> Type of native format
      * @return Native serialized format
      */
-    <T> T getSerialized();
-
+    T getSerialized();
 }

--- a/core/src/main/java/ch/cyberduck/core/serializer/TransferDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/TransferDictionary.java
@@ -41,10 +41,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class TransferDictionary {
+public class TransferDictionary<T> {
     private static final Logger log = LogManager.getLogger(TransferDictionary.class);
 
-    private final DeserializerFactory factory;
+    private final DeserializerFactory<T> factory;
     private final ProtocolFactory protocols;
 
     public TransferDictionary() {
@@ -52,26 +52,26 @@ public class TransferDictionary {
     }
 
     public TransferDictionary(final ProtocolFactory protocols) {
-        this(protocols, new DeserializerFactory());
+        this(protocols, new DeserializerFactory<>());
     }
 
-    public TransferDictionary(final DeserializerFactory factory) {
+    public TransferDictionary(final DeserializerFactory<T> factory) {
         this(ProtocolFactory.get(), factory);
     }
 
-    public TransferDictionary(final ProtocolFactory protocols, final DeserializerFactory factory) {
+    public TransferDictionary(final ProtocolFactory protocols, final DeserializerFactory<T> factory) {
         this.protocols = protocols;
         this.factory = factory;
     }
 
-    public <T> Transfer deserialize(final T serialized) {
-        final Deserializer dict = factory.create(serialized);
-        final Object hostObj = dict.objectForKey("Host");
+    public Transfer deserialize(final T serialized) {
+        final Deserializer<T> dict = factory.create(serialized);
+        final T hostObj = dict.objectForKey("Host");
         if(null == hostObj) {
             log.warn("Missing host in transfer");
             return null;
         }
-        final Host host = new HostDictionary(protocols, factory).deserialize(hostObj);
+        final Host host = new HostDictionary<>(protocols, factory).deserialize(hostObj);
         if(null == host) {
             log.warn("Invalid host in transfer");
             return null;
@@ -81,7 +81,7 @@ public class TransferDictionary {
         final List<TransferItem> roots = new ArrayList<>();
         if(itemsObj != null) {
             for(T rootDict : itemsObj) {
-                final TransferItem item = new TransferItemDictionary(factory).deserialize(rootDict);
+                final TransferItem item = new TransferItemDictionary<>(factory).deserialize(rootDict);
                 if(null == item) {
                     log.warn("Invalid item in transfer");
                     continue;
@@ -93,7 +93,7 @@ public class TransferDictionary {
         final List<T> rootsObj = dict.listForKey("Roots");
         if(rootsObj != null) {
             for(T rootDict : rootsObj) {
-                final Path remote = new PathDictionary(factory).deserialize(rootDict);
+                final Path remote = new PathDictionary<>(factory).deserialize(rootDict);
                 if(null == remote) {
                     log.warn("Invalid remote in transfer");
                     continue;
@@ -106,10 +106,10 @@ public class TransferDictionary {
                     Local local = LocalFactory.get(localObjDeprecated);
                     item.setLocal(local);
                 }
-                final Object localObj
-                    = factory.create(rootDict).objectForKey("Local Dictionary");
+                final T localObj
+                        = factory.create(rootDict).objectForKey("Local Dictionary");
                 if(localObj != null) {
-                    Local local = new LocalDictionary(factory).deserialize(localObj);
+                    Local local = new LocalDictionary<>(factory).deserialize(localObj);
                     if(null == local) {
                         log.warn("Invalid local in transfer item");
                         continue;
@@ -172,7 +172,7 @@ public class TransferDictionary {
                 }
                 break;
             case copy:
-                Object destinationObj = dict.objectForKey("Destination");
+                final T destinationObj = dict.objectForKey("Destination");
                 if(null == destinationObj) {
                     log.warn("Missing destination for copy transfer");
                     return null;
@@ -185,13 +185,13 @@ public class TransferDictionary {
                 if(roots.size() == destinations.size()) {
                     final Map<Path, Path> files = new HashMap<>();
                     for(int i = 0; i < roots.size(); i++) {
-                        final Path target = new PathDictionary(factory).deserialize(destinations.get(i));
+                        final Path target = new PathDictionary<>(factory).deserialize(destinations.get(i));
                         if(null == target) {
                             continue;
                         }
                         files.put(roots.get(i).remote, target);
                     }
-                    final Host target = new HostDictionary(protocols, factory).deserialize(destinationObj);
+                    final Host target = new HostDictionary<>(protocols, factory).deserialize(destinationObj);
                     if(null == target) {
                         log.warn("Missing target host in copy transfer");
                         return null;

--- a/core/src/main/java/ch/cyberduck/core/serializer/TransferItemDictionary.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/TransferItemDictionary.java
@@ -22,28 +22,28 @@ import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Path;
 import ch.cyberduck.core.transfer.TransferItem;
 
-public class TransferItemDictionary {
+public class TransferItemDictionary<T> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<T> deserializer;
 
     public TransferItemDictionary() {
-        this.deserializer = new DeserializerFactory();
+        this.deserializer = new DeserializerFactory<>();
     }
 
-    public TransferItemDictionary(final DeserializerFactory deserializer) {
+    public TransferItemDictionary(final DeserializerFactory<T> deserializer) {
         this.deserializer = deserializer;
     }
 
-    public <T> TransferItem deserialize(T serialized) {
-        final Deserializer dict = deserializer.create(serialized);
-        final Path remote = new PathDictionary(deserializer).deserialize(dict.objectForKey("Remote"));
+    public TransferItem deserialize(T serialized) {
+        final Deserializer<T> dict = deserializer.create(serialized);
+        final Path remote = new PathDictionary<>(deserializer).deserialize(dict.objectForKey("Remote"));
         if(null == remote) {
             return null;
         }
         final TransferItem item = new TransferItem(remote);
-        final Object localObj = dict.objectForKey("Local Dictionary");
+        final T localObj = dict.objectForKey("Local Dictionary");
         if(localObj != null) {
-            item.setLocal(new LocalDictionary(deserializer).deserialize((localObj)));
+            item.setLocal(new LocalDictionary<>(deserializer).deserialize((localObj)));
         }
         return item;
     }

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/HostPlistReader.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/HostPlistReader.java
@@ -20,24 +20,26 @@ package ch.cyberduck.core.serializer.impl.dd;
 
 import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Host;
+import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.serializer.HostDictionary;
 
 import com.dd.plist.NSDictionary;
 
 public class HostPlistReader extends PlistReader<Host> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<NSDictionary> deserializer = new DeserializerFactory<>();
+    private final ProtocolFactory protocols;
 
     public HostPlistReader() {
-        this.deserializer = new DeserializerFactory();
+        this(ProtocolFactory.get());
     }
 
-    public HostPlistReader(final DeserializerFactory deserializer) {
-        this.deserializer = deserializer;
+    public HostPlistReader(final ProtocolFactory protocols) {
+        this.protocols = protocols;
     }
 
     @Override
     public Host deserialize(final NSDictionary dict) {
-        return new HostDictionary(deserializer).deserialize(dict);
+        return new HostDictionary<>(protocols, deserializer).deserialize(dict);
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistReader.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistReader.java
@@ -18,15 +18,12 @@ package ch.cyberduck.core.serializer.impl.dd;
  * feedback@cyberduck.io
  */
 
-import ch.cyberduck.core.Collection;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Serializable;
 import ch.cyberduck.core.exception.AccessDeniedException;
 import ch.cyberduck.core.exception.LocalAccessDeniedException;
 import ch.cyberduck.core.serializer.Reader;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -34,36 +31,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 
-import com.dd.plist.NSArray;
 import com.dd.plist.NSDictionary;
 import com.dd.plist.NSObject;
 import com.dd.plist.PropertyListFormatException;
 import com.dd.plist.XMLPropertyListParser;
 
 public abstract class PlistReader<S extends Serializable> implements Reader<S> {
-    private static final Logger log = LogManager.getLogger(PlistReader.class);
-
-    @Override
-    public Collection<S> readCollection(final Local file) throws AccessDeniedException {
-        final Collection<S> c = new Collection<>();
-        final NSArray list = (NSArray) this.parse(file.getInputStream());
-        if(null == list) {
-            log.error(String.format("Invalid bookmark file %s", file));
-            return c;
-        }
-        for(int i = 0; i < list.count(); i++) {
-            NSObject next = list.objectAtIndex(i);
-            if(next instanceof NSDictionary) {
-                final NSDictionary dict = (NSDictionary) next;
-                final S object = this.deserialize(dict);
-                if(null == object) {
-                    continue;
-                }
-                c.add(object);
-            }
-        }
-        return c;
-    }
 
     /**
      * @param file A valid bookmark dictionary
@@ -95,7 +68,8 @@ public abstract class PlistReader<S extends Serializable> implements Reader<S> {
         try {
             return XMLPropertyListParser.parse(in);
         }
-        catch(ParserConfigurationException | IOException | SAXException | ParseException | PropertyListFormatException e) {
+        catch(ParserConfigurationException | IOException | SAXException | ParseException |
+              PropertyListFormatException e) {
             throw new AccessDeniedException("Failure parsing XML property list", e);
         }
     }

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistSerializer.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistSerializer.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import com.dd.plist.NSArray;
 import com.dd.plist.NSDictionary;
 
-public class PlistSerializer implements Serializer {
+public class PlistSerializer implements Serializer<NSDictionary> {
 
-    final NSDictionary dict;
+    private final NSDictionary dict;
 
     public PlistSerializer() {
         this(new NSDictionary());
@@ -46,15 +46,15 @@ public class PlistSerializer implements Serializer {
 
     @Override
     public void setObjectForKey(final Serializable value, final String key) {
-        dict.put(key, value.<NSDictionary>serialize(new PlistSerializer()));
+        dict.put(key, value.serialize(new PlistSerializer()));
     }
 
     @Override
-    public <T extends Serializable> void setListForKey(final Collection<T> value, final String key) {
+    public <O extends Serializable> void setListForKey(final Collection<O> value, final String key) {
         final NSArray list = new NSArray(value.size());
         int i = 0;
         for(Serializable serializable : value) {
-            list.setValue(i, serializable.<NSDictionary>serialize(new PlistSerializer()));
+            list.setValue(i, serializable.serialize(new PlistSerializer()));
             i++;
         }
         dict.put(key, list);

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistWriter.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/PlistWriter.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import com.dd.plist.NSArray;
-import com.dd.plist.NSDictionary;
 
 public class PlistWriter<S extends Serializable> implements Writer<S> {
 
@@ -40,7 +39,7 @@ public class PlistWriter<S extends Serializable> implements Writer<S> {
         final NSArray list = new NSArray(collection.size());
         int i = 0;
         for(S bookmark : collection) {
-            list.setValue(i, bookmark.<NSDictionary>serialize(new PlistSerializer()));
+            list.setValue(i, bookmark.serialize(new PlistSerializer()));
             i++;
         }
         final String content = list.toXMLPropertyList();
@@ -54,7 +53,7 @@ public class PlistWriter<S extends Serializable> implements Writer<S> {
 
     @Override
     public void write(final S item, final Local file) throws AccessDeniedException {
-        final String content = item.<NSDictionary>serialize(new PlistSerializer()).toXMLPropertyList();
+        final String content = item.serialize(new PlistSerializer()).toXMLPropertyList();
         try (final OutputStream out = file.getOutputStream(false)) {
             IOUtils.write(content, out, StandardCharsets.UTF_8);
         }

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReader.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReader.java
@@ -20,35 +20,35 @@ package ch.cyberduck.core.serializer.impl.dd;
 
 import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Profile;
+import ch.cyberduck.core.Protocol;
 import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.serializer.ProfileDictionary;
+
+import java.util.function.Predicate;
 
 import com.dd.plist.NSDictionary;
 
 public class ProfilePlistReader extends PlistReader<Profile> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<NSDictionary> deserializer = new DeserializerFactory<>();
     private final ProtocolFactory protocols;
+    private final Predicate<Protocol> filter;
 
     public ProfilePlistReader() {
-        this(new DeserializerFactory());
-    }
-
-    public ProfilePlistReader(final DeserializerFactory deserializer) {
-        this(ProtocolFactory.get(), deserializer);
+        this(ProtocolFactory.get());
     }
 
     public ProfilePlistReader(final ProtocolFactory protocols) {
-        this(protocols, new DeserializerFactory());
+        this(protocols, protocol -> true);
     }
 
-    public ProfilePlistReader(final ProtocolFactory protocols, final DeserializerFactory deserializer) {
-        this.deserializer = deserializer;
+    public ProfilePlistReader(final ProtocolFactory protocols, final Predicate<Protocol> parent) {
         this.protocols = protocols;
+        this.filter = parent;
     }
 
     @Override
     public Profile deserialize(final NSDictionary dict) {
-        return new ProfileDictionary(protocols, deserializer).deserialize(dict);
+        return new ProfileDictionary<>(protocols, deserializer).deserialize(dict, filter);
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/TransferPlistReader.java
+++ b/core/src/main/java/ch/cyberduck/core/serializer/impl/dd/TransferPlistReader.java
@@ -27,28 +27,19 @@ import com.dd.plist.NSDictionary;
 
 public class TransferPlistReader extends PlistReader<Transfer> {
 
-    private final DeserializerFactory deserializer;
+    private final DeserializerFactory<NSDictionary> deserializer = new DeserializerFactory<>();
     private final ProtocolFactory protocols;
 
     public TransferPlistReader() {
-        this(new DeserializerFactory());
-    }
-
-    public TransferPlistReader(final DeserializerFactory deserializer) {
-        this(ProtocolFactory.get(), deserializer);
+        this(ProtocolFactory.get());
     }
 
     public TransferPlistReader(final ProtocolFactory protocols) {
-        this(protocols, new DeserializerFactory());
-    }
-
-    public TransferPlistReader(final ProtocolFactory protocols, final DeserializerFactory deserializer) {
-        this.deserializer = deserializer;
         this.protocols = protocols;
     }
 
     @Override
     public Transfer deserialize(final NSDictionary dict) {
-        return new TransferDictionary(protocols, deserializer).deserialize(dict);
+        return new TransferDictionary<>(protocols, deserializer).deserialize(dict);
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/shared/WorkdirHomeFeature.java
+++ b/core/src/main/java/ch/cyberduck/core/shared/WorkdirHomeFeature.java
@@ -39,7 +39,7 @@ public class WorkdirHomeFeature extends AbstractHomeFeature {
     @Override
     public Path find() throws BackgroundException {
         if(host.getWorkdir() != null) {
-            return new PathDictionary().deserialize(host.getWorkdir().serialize(SerializerFactory.get()));
+            return new PathDictionary<>().deserialize(host.getWorkdir().serialize(SerializerFactory.get()));
         }
         if(log.isDebugEnabled()) {
             log.debug(String.format("No workdir set for bookmark %s", host));

--- a/core/src/main/java/ch/cyberduck/core/transfer/CopyTransfer.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/CopyTransfer.java
@@ -107,7 +107,7 @@ public class CopyTransfer extends Transfer {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(this.getType().name(), "Type");
         dict.setObjectForKey(host, "Host");
         if(destination != null) {

--- a/core/src/main/java/ch/cyberduck/core/transfer/SyncTransfer.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/SyncTransfer.java
@@ -103,7 +103,7 @@ public class SyncTransfer extends Transfer {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(this.getType().name(), "Type");
         dict.setObjectForKey(host, "Host");
         dict.setListForKey(roots, "Items");

--- a/core/src/main/java/ch/cyberduck/core/transfer/Transfer.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/Transfer.java
@@ -171,7 +171,7 @@ public abstract class Transfer implements Serializable {
 
     public abstract Transfer withCache(final Cache<Path> cache);
 
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setStringForKey(this.getType().name(), "Type");
         dict.setObjectForKey(host, "Host");
         dict.setListForKey(roots, "Items");

--- a/core/src/main/java/ch/cyberduck/core/transfer/TransferItem.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/TransferItem.java
@@ -41,7 +41,7 @@ public class TransferItem implements Referenceable, Serializable {
     }
 
     @Override
-    public <T> T serialize(final Serializer dict) {
+    public <T> T serialize(final Serializer<T> dict) {
         dict.setObjectForKey(remote, "Remote");
         if(local != null) {
             dict.setObjectForKey(local, "Local Dictionary");

--- a/core/src/test/java/ch/cyberduck/core/PathAttributesTest.java
+++ b/core/src/test/java/ch/cyberduck/core/PathAttributesTest.java
@@ -80,7 +80,7 @@ public class PathAttributesTest {
         final Map<String, String> custom = new HashMap<>(attributes.getCustom());
         custom.put("key", "value");
         attributes.setCustom(custom);
-        final PathAttributes deserialized = new PathAttributesDictionary().deserialize(attributes.serialize(SerializerFactory.get()));
+        final PathAttributes deserialized = new PathAttributesDictionary<>().deserialize(attributes.serialize(SerializerFactory.get()));
         assertEquals(attributes.getSize(), deserialized.getSize());
         assertEquals(attributes.getModificationDate(), deserialized.getModificationDate());
         assertEquals(attributes.getPermission(), deserialized.getPermission());

--- a/core/src/test/java/ch/cyberduck/core/PathTest.java
+++ b/core/src/test/java/ch/cyberduck/core/PathTest.java
@@ -31,28 +31,28 @@ public class PathTest {
     @Test
     public void testDictionaryDirectory() {
         Path path = new Path("/path", EnumSet.of(Path.Type.directory));
-        assertEquals(path, new PathDictionary().deserialize(path.serialize(SerializerFactory.get())));
+        assertEquals(path, new PathDictionary<>().deserialize(path.serialize(SerializerFactory.get())));
     }
 
     @Test
     public void testDictionaryFile() {
         Path path = new Path("/path", EnumSet.of(Path.Type.file));
-        assertEquals(path, new PathDictionary().deserialize((path.serialize(SerializerFactory.get()))));
+        assertEquals(path, new PathDictionary<>().deserialize((path.serialize(SerializerFactory.get()))));
     }
 
     @Test
     public void testDictionaryFileSymbolicLink() {
         Path path = new Path("/path", EnumSet.of(Path.Type.file, Path.Type.symboliclink));
-        assertEquals(path, new PathDictionary().deserialize(path.serialize(SerializerFactory.get())));
+        assertEquals(path, new PathDictionary<>().deserialize(path.serialize(SerializerFactory.get())));
         assertEquals(EnumSet.of(Path.Type.file, Path.Type.symboliclink),
-                new PathDictionary().deserialize(path.serialize(SerializerFactory.get())).getType());
+                new PathDictionary<>().deserialize(path.serialize(SerializerFactory.get())).getType());
     }
 
     @Test
     public void testDictionaryRegion() {
         Path path = new Path("/path/f", EnumSet.of(Path.Type.file));
         path.attributes().setRegion("r");
-        final Path deserialized = new PathDictionary().deserialize(path.serialize(SerializerFactory.get()));
+        final Path deserialized = new PathDictionary<>().deserialize(path.serialize(SerializerFactory.get()));
         assertEquals(path, deserialized);
         assertEquals("r", deserialized.attributes().getRegion());
         assertEquals("r", deserialized.getParent().attributes().getRegion());
@@ -77,7 +77,7 @@ public class PathTest {
     public void testDictionaryRegionParentOnly() {
         Path path = new Path("/root/path", EnumSet.of(Path.Type.file));
         path.getParent().attributes().setRegion("r");
-        assertEquals(path, new PathDictionary().deserialize(path.serialize(SerializerFactory.get())));
+        assertEquals(path, new PathDictionary<>().deserialize(path.serialize(SerializerFactory.get())));
     }
 
     @Test

--- a/core/src/test/java/ch/cyberduck/core/ProtocolFactoryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/ProtocolFactoryTest.java
@@ -259,12 +259,17 @@ public class ProtocolFactoryTest {
 
             @Override
             public boolean isEnabled() {
-                return false;
+                return true;
+            }
+
+            @Override
+            public boolean isBundled() {
+                return true;
             }
         }).collect(Collectors.toSet()));
         final ProfilePlistReader reader = new ProfilePlistReader(factory);
         final Local file = new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile");
-        Profile profile = reader.read(file);
+        final Profile profile = reader.read(file);
         factory.register(file);
         assertTrue(profile.isEnabled());
         factory.unregister(profile);

--- a/core/src/test/java/ch/cyberduck/core/profiles/RemoteProfilesFinderTest.java
+++ b/core/src/test/java/ch/cyberduck/core/profiles/RemoteProfilesFinderTest.java
@@ -25,7 +25,6 @@ import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.Scheme;
 import ch.cyberduck.core.TestProtocol;
 import ch.cyberduck.core.proxy.Proxy;
-import ch.cyberduck.core.serializer.impl.dd.ProfilePlistReader;
 
 import org.junit.Test;
 
@@ -70,7 +69,6 @@ public class RemoteProfilesFinderTest {
                 return false;
             }
         })));
-        final ProfilePlistReader reader = new ProfilePlistReader(protocols);
         final TestProtocol protocol = new TestProtocol() {
             @Override
             public String getIdentifier() {

--- a/core/src/test/java/ch/cyberduck/core/serializer/AclDictionaryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/AclDictionaryTest.java
@@ -28,7 +28,7 @@ public class AclDictionaryTest {
     @Test
     public void testSerialize() {
         Acl attributes = new Acl(new Acl.UserAndRole(new Acl.CanonicalUser(""), new Acl.Role("w")));
-        Acl clone = new AclDictionary().deserialize(attributes.serialize(SerializerFactory.get()));
+        Acl clone = new AclDictionary<>().deserialize(attributes.serialize(SerializerFactory.get()));
         assertEquals(attributes.get(new Acl.CanonicalUser()), clone.get(new Acl.CanonicalUser()));
         assertNotEquals(attributes, new Acl(new Acl.UserAndRole(new Acl.CanonicalUser("t"), new Acl.Role("w"))));
         assertEquals(attributes.get(new Acl.CanonicalUser()), clone.get(new Acl.CanonicalUser()));

--- a/core/src/test/java/ch/cyberduck/core/serializer/HostDictionaryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/HostDictionaryTest.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 
+import com.dd.plist.NSDictionary;
+
 import static org.junit.Assert.assertEquals;
 
 public class HostDictionaryTest {
@@ -48,19 +50,19 @@ public class HostDictionaryTest {
         final Path container = new Path("/container", EnumSet.of(Path.Type.directory));
         container.attributes().setRegion("r");
         h.setWorkdir(container);
-        final Host deserialized = new HostDictionary(new DeserializerFactory()).deserialize(h.serialize(SerializerFactory.get()));
+        final Host deserialized = new HostDictionary<>(new DeserializerFactory<>()).deserialize(h.serialize(SerializerFactory.get()));
         assertEquals(h, deserialized);
         assertEquals("r", deserialized.getWorkdir().attributes().getRegion());
     }
 
     @Test
     public void testDeserialize() {
-        final Serializer dict = SerializerFactory.get();
+        final Serializer<NSDictionary> dict = SerializerFactory.get();
         dict.setStringForKey("test", "Protocol");
         dict.setStringForKey("unknown provider", "Provider");
         dict.setStringForKey("h", "Hostname");
         dict.setStringListForKey(Arrays.asList("a", "b"), "Labels");
-        final Host host = new HostDictionary(new DeserializerFactory()).deserialize(dict.getSerialized());
+        final Host host = new HostDictionary<>(new DeserializerFactory<>()).deserialize(dict.getSerialized());
         assertEquals(new TestProtocol(), host.getProtocol());
         assertEquals(new HashSet<>(Arrays.asList("a", "b")), host.getLabels());
     }

--- a/core/src/test/java/ch/cyberduck/core/serializer/PathAttributesDictionaryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/PathAttributesDictionaryTest.java
@@ -32,8 +32,7 @@ public class PathAttributesDictionaryTest {
     @Test
     public void testSerialize() {
         PathAttributes attributes = new PathAttributes();
-        PathAttributes clone = new PathAttributesDictionary().deserialize(attributes.serialize(SerializerFactory.get()));
-
+        PathAttributes clone = new PathAttributesDictionary<>().deserialize(attributes.serialize(SerializerFactory.get()));
         assertEquals(clone.getPermission(), attributes.getPermission());
         assertEquals(clone.getModificationDate(), attributes.getModificationDate());
     }
@@ -45,7 +44,7 @@ public class PathAttributesDictionaryTest {
         attributes.setChecksum(Checksum.parse("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
         attributes.setModificationDate(5343L);
         attributes.setLink(new DescriptiveUrl(URI.create("https://cyberduck.io/"), DescriptiveUrl.Type.signed));
-        final PathAttributes deserialized = new PathAttributesDictionary().deserialize(attributes.serialize(SerializerFactory.get()));
+        final PathAttributes deserialized = new PathAttributesDictionary<>().deserialize(attributes.serialize(SerializerFactory.get()));
         assertEquals(attributes, deserialized);
         assertEquals(attributes.hashCode(), deserialized.hashCode());
         assertEquals(attributes.getLink(), deserialized.getLink());
@@ -60,7 +59,7 @@ public class PathAttributesDictionaryTest {
         attributes.setVersionId("v-1");
         attributes.setFileId("myUniqueId");
         attributes.setModificationDate(System.currentTimeMillis());
-        assertEquals(attributes, new PathAttributesDictionary().deserialize(attributes.serialize(SerializerFactory.get())));
-        assertEquals(attributes.hashCode(), new PathAttributesDictionary().deserialize(attributes.serialize(SerializerFactory.get())).hashCode());
+        assertEquals(attributes, new PathAttributesDictionary<>().deserialize(attributes.serialize(SerializerFactory.get())));
+        assertEquals(attributes.hashCode(), new PathAttributesDictionary<>().deserialize(attributes.serialize(SerializerFactory.get())).hashCode());
     }
 }

--- a/core/src/test/java/ch/cyberduck/core/serializer/TransferDictionaryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/TransferDictionaryTest.java
@@ -64,7 +64,7 @@ public class TransferDictionaryTest {
         Transfer t = new DownloadTransfer(new Host(new TestProtocol(), "t"), test, new NullLocal(UUID.randomUUID().toString(), "transfer"));
         t.addSize(4L);
         t.addTransferred(3L);
-        final Transfer serialized = new TransferDictionary().deserialize(t.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>().deserialize(t.serialize(SerializerFactory.get()));
         assertNotSame(t, serialized);
         assertEquals(t.getRoots(), serialized.getRoots());
         assertEquals(t.getBandwidth(), serialized.getBandwidth());
@@ -80,7 +80,7 @@ public class TransferDictionaryTest {
                 new Local(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString()));
         t.addSize(4L);
         t.addTransferred(3L);
-        final Transfer serialized = new TransferDictionary().deserialize(t.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>().deserialize(t.serialize(SerializerFactory.get()));
         assertNotSame(t, serialized);
         assertEquals(t.getRoots(), serialized.getRoots());
         assertEquals(t.getBandwidth(), serialized.getBandwidth());
@@ -94,7 +94,7 @@ public class TransferDictionaryTest {
                 new TransferItem(new Path("t", EnumSet.of(Path.Type.file)), new NullLocal(System.getProperty("java.io.tmpdir"), "t")));
         t.addSize(4L);
         t.addTransferred(3L);
-        final Transfer serialized = new TransferDictionary().deserialize(t.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>().deserialize(t.serialize(SerializerFactory.get()));
         assertNotSame(t, serialized);
         assertEquals(t.getRoots(), serialized.getRoots());
         assertEquals(t.getBandwidth(), serialized.getBandwidth());
@@ -122,7 +122,7 @@ public class TransferDictionaryTest {
                 return TransferAction.upload;
             }
         }, new DisabledListProgressListener());
-        final Transfer serialized = new TransferDictionary().deserialize(transfer.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>().deserialize(transfer.serialize(SerializerFactory.get()));
         assertNotSame(transfer, serialized);
         assertEquals(TransferAction.upload, serialized.action(null, null, true, false, new DisabledTransferPrompt() {
             @Override
@@ -168,7 +168,7 @@ public class TransferDictionaryTest {
         }, new DisabledTransferErrorCallback(),
             new DisabledProgressListener(), new DisabledStreamListener(), new DisabledLoginCallback(), new DisabledNotificationService()).run(session);
         assertTrue(t.isComplete());
-        final Transfer serialized = new TransferDictionary().deserialize(t.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>().deserialize(t.serialize(SerializerFactory.get()));
         assertNotSame(t, serialized);
         assertTrue(serialized.isComplete());
     }

--- a/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/HostPlistReaderTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/HostPlistReaderTest.java
@@ -18,7 +18,6 @@ package ch.cyberduck.core.serializer.impl.dd;
  * feedback@cyberduck.io
  */
 
-import ch.cyberduck.core.DeserializerFactory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.ProtocolFactory;
@@ -41,7 +40,7 @@ public class HostPlistReaderTest {
 
     @Test(expected = LocalAccessDeniedException.class)
     public void testDeserializeNoSuchFile() throws Exception {
-        final HostPlistReader reader = new HostPlistReader(new DeserializerFactory());
+        final HostPlistReader reader = new HostPlistReader();
         reader.read(new Local("test"));
     }
 

--- a/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReaderTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReaderTest.java
@@ -186,6 +186,7 @@ public class ProfilePlistReaderTest {
         assertEquals(profile, reader.read(
             new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile")
         ));
+        assertFalse(profile.isBundled());
         assertEquals(Protocol.Type.s3, profile.getType());
         assertEquals(new TestProtocol(), profile.getProtocol());
         assertTrue(profile.isHostnameConfigurable());
@@ -220,6 +221,7 @@ public class ProfilePlistReaderTest {
         assertEquals(profile, reader.read(
             new Local("src/test/resources/Test S3 (HTTPS).cyberduckprofile")
         ));
+        assertFalse(profile.isBundled());
         assertEquals(Protocol.Type.s3, profile.getType());
         assertEquals(new TestProtocol(), profile.getProtocol());
         assertTrue(profile.isHostnameConfigurable());

--- a/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReaderTest.java
+++ b/core/src/test/java/ch/cyberduck/core/serializer/impl/dd/ProfilePlistReaderTest.java
@@ -52,7 +52,7 @@ public class ProfilePlistReaderTest {
                 return false;
             }
         }))).read(
-            new Local("src/test/resources/Test Dropbox.cyberduckprofile")
+                new Local("src/test/resources/Test Dropbox.cyberduckprofile")
         );
         assertNotNull(profile);
     }
@@ -70,7 +70,7 @@ public class ProfilePlistReaderTest {
                 return false;
             }
         }))).read(
-            new Local("src/test/resources/Unknown.cyberduckprofile")
+                new Local("src/test/resources/Unknown.cyberduckprofile")
         );
     }
 
@@ -82,7 +82,7 @@ public class ProfilePlistReaderTest {
                 return false;
             }
         }))).read(
-            new Local("src/test/resources/Custom Regions S3.cyberduckprofile")
+                new Local("src/test/resources/Custom Regions S3.cyberduckprofile")
         );
         assertNotNull(profile);
         final Set<Location.Name> regions = profile.getRegions();
@@ -105,11 +105,11 @@ public class ProfilePlistReaderTest {
             }
         })));
         final Profile profile = reader.read(
-            new Local("src/test/resources/Eucalyptus Walrus S3.cyberduckprofile")
+                new Local("src/test/resources/Eucalyptus Walrus S3.cyberduckprofile")
         );
         assertNotNull(profile);
         assertEquals(profile, reader.read(
-            new Local("src/test/resources/Eucalyptus Walrus S3.cyberduckprofile")
+                new Local("src/test/resources/Eucalyptus Walrus S3.cyberduckprofile")
         ));
         assertEquals(Protocol.Type.s3, profile.getType());
         assertEquals(new TestProtocol(), profile.getProtocol());
@@ -132,11 +132,11 @@ public class ProfilePlistReaderTest {
             }
         })));
         final Profile https = reader.read(
-            new Local("src/test/resources/Openstack Swift (Swauth).cyberduckprofile")
+                new Local("src/test/resources/Openstack Swift (Swauth).cyberduckprofile")
         );
         assertNotNull(https);
         final Profile http = reader.read(
-            new Local("src/test/resources/Openstack Swift (Swauth HTTP).cyberduckprofile")
+                new Local("src/test/resources/Openstack Swift (Swauth HTTP).cyberduckprofile")
         );
         assertNotNull(http);
         assertNotEquals(https, http);
@@ -156,11 +156,11 @@ public class ProfilePlistReaderTest {
             }
         })));
         final Profile keystone = reader.read(
-            new Local("src/test/resources/Openstack Swift (Keystone).cyberduckprofile")
+                new Local("src/test/resources/Openstack Swift (Keystone).cyberduckprofile")
         );
         assertNotNull(keystone);
         final Profile swauth = reader.read(
-            new Local("src/test/resources/Openstack Swift (Swauth).cyberduckprofile")
+                new Local("src/test/resources/Openstack Swift (Swauth).cyberduckprofile")
         );
         assertNotNull(swauth);
         assertNotEquals(keystone, swauth);
@@ -180,11 +180,11 @@ public class ProfilePlistReaderTest {
             }
         })));
         final Profile profile = reader.read(
-            new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile")
+                new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile")
         );
         assertNotNull(profile);
         assertEquals(profile, reader.read(
-            new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile")
+                new Local("src/test/resources/Test S3 (HTTP).cyberduckprofile")
         ));
         assertFalse(profile.isBundled());
         assertEquals(Protocol.Type.s3, profile.getType());
@@ -215,11 +215,11 @@ public class ProfilePlistReaderTest {
             }
         })));
         final Profile profile = reader.read(
-            new Local("src/test/resources/Test S3 (HTTPS).cyberduckprofile")
+                new Local("src/test/resources/Test S3 (HTTPS).cyberduckprofile")
         );
         assertNotNull(profile);
         assertEquals(profile, reader.read(
-            new Local("src/test/resources/Test S3 (HTTPS).cyberduckprofile")
+                new Local("src/test/resources/Test S3 (HTTPS).cyberduckprofile")
         ));
         assertFalse(profile.isBundled());
         assertEquals(Protocol.Type.s3, profile.getType());

--- a/core/src/test/java/ch/cyberduck/core/transfer/CopyTransferTest.java
+++ b/core/src/test/java/ch/cyberduck/core/transfer/CopyTransferTest.java
@@ -49,7 +49,7 @@ public class CopyTransferTest {
                 new Host(new TestProtocol()), Collections.singletonMap(test, new Path("d", EnumSet.of(Path.Type.file))));
         t.addSize(4L);
         t.addTransferred(3L);
-        final Transfer serialized = new TransferDictionary(new ProtocolFactory(Collections.singleton(new TestProtocol()))).deserialize(t.serialize(SerializerFactory.get()));
+        final Transfer serialized = new TransferDictionary<>(new ProtocolFactory(Collections.singleton(new TestProtocol()))).deserialize(t.serialize(SerializerFactory.get()));
         assertNotSame(t, serialized);
         assertEquals(t.roots, serialized.getRoots());
         assertEquals(t.getBandwidth(), serialized.getBandwidth());

--- a/cryptomator/src/test/java/ch/cyberduck/core/cryptomator/CryptoVaultTest.java
+++ b/cryptomator/src/test/java/ch/cyberduck/core/cryptomator/CryptoVaultTest.java
@@ -207,7 +207,7 @@ public class CryptoVaultTest {
             }
         }, new DisabledPasswordStore()).getHome());
         assertEquals(Vault.State.open, vault.getState());
-        assertEquals(home, new PathDictionary().deserialize(home.serialize(SerializerFactory.get())));
+        assertEquals(home, new PathDictionary<>().deserialize(home.serialize(SerializerFactory.get())));
         vault.close();
     }
 

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BookmarkController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BookmarkController.java
@@ -240,7 +240,7 @@ public class BookmarkController extends SheetController implements CollectionLis
             @Override
             public void change(final Host bookmark) {
                 updateField(hostField, bookmark.getHostname());
-                hostField.setEnabled(bookmark.getProtocol().isHostnameConfigurable());
+                hostField.setHidden(!bookmark.getProtocol().isHostnameConfigurable());
                 hostField.cell().setPlaceholderString(bookmark.getProtocol().getHostnamePlaceholder());
             }
         });
@@ -320,7 +320,7 @@ public class BookmarkController extends SheetController implements CollectionLis
             @Override
             public void change(final Host bookmark) {
                 updateField(portField, String.valueOf(bookmark.getPort()));
-                portField.setEnabled(bookmark.getProtocol().isPortConfigurable());
+                portField.setHidden(!bookmark.getProtocol().isPortConfigurable());
             }
         });
     }
@@ -346,7 +346,7 @@ public class BookmarkController extends SheetController implements CollectionLis
             @Override
             public void change(final Host bookmark) {
                 updateField(pathField, bookmark.getDefaultPath());
-                pathField.setEnabled(bookmark.getProtocol().isPathConfigurable());
+                pathField.setHidden(!bookmark.getProtocol().isPathConfigurable());
             }
         });
     }
@@ -380,7 +380,7 @@ public class BookmarkController extends SheetController implements CollectionLis
             public void change(final Host bookmark) {
                 updateField(usernameField, bookmark.getCredentials().getUsername());
                 usernameField.cell().setPlaceholderString(bookmark.getProtocol().getUsernamePlaceholder());
-                usernameField.setEnabled(options.user && !bookmark.getCredentials().isAnonymousLogin());
+                usernameField.setHidden(!options.user && !bookmark.getCredentials().isAnonymousLogin());
             }
         });
     }
@@ -411,7 +411,7 @@ public class BookmarkController extends SheetController implements CollectionLis
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(final Host bookmark) {
-                anonymousCheckbox.setEnabled(options.anonymous);
+                anonymousCheckbox.setHidden(!options.anonymous);
                 anonymousCheckbox.setState(bookmark.getCredentials().isAnonymousLogin() ? NSCell.NSOnState : NSCell.NSOffState);
             }
         });
@@ -442,7 +442,7 @@ public class BookmarkController extends SheetController implements CollectionLis
             @Override
             public void change(final Host bookmark) {
                 passwordField.cell().setPlaceholderString(options.getPasswordPlaceholder());
-                passwordField.setEnabled(options.password && !bookmark.getCredentials().isAnonymousLogin());
+                passwordField.setHidden(!options.password || !bookmark.getCredentials().isAnonymousLogin());
                 if(options.keychain && options.password) {
                     if(StringUtils.isBlank(bookmark.getHostname())) {
                         return;
@@ -546,7 +546,7 @@ public class BookmarkController extends SheetController implements CollectionLis
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(final Host bookmark) {
-                privateKeyPopup.setEnabled(options.publickey);
+                privateKeyPopup.setHidden(!options.publickey);
                 if(bookmark.getCredentials().isPublicKeyAuthentication()) {
                     privateKeyPopup.selectItemAtIndex(privateKeyPopup.indexOfItemWithRepresentedObject(bookmark.getCredentials().getIdentity().getAbsolute()));
                 }

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BrowserController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BrowserController.java
@@ -720,7 +720,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
     @Action
     public boolean performDragOperation(final NSDraggingInfo sender) {
         for(Host bookmark : HostPasteboard.getPasteboard()) {
-            final Host duplicate = new HostDictionary().deserialize(bookmark.serialize(SerializerFactory.get()));
+            final Host duplicate = new HostDictionary<>().deserialize(bookmark.serialize(SerializerFactory.get()));
             // Make sure a new UUID is assigned for duplicate
             duplicate.setUuid(null);
             bookmarks.add(0, duplicate);
@@ -1878,7 +1878,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
     public void duplicateBookmarkButtonClicked(final ID sender) {
         final Host selected = bookmarkModel.getSource().get(bookmarkTable.selectedRow().intValue());
         this.selectBookmarks(BookmarkSwitchSegement.bookmarks);
-        final Host duplicate = new HostDictionary().deserialize(selected.serialize(SerializerFactory.get()));
+        final Host duplicate = new HostDictionary<>().deserialize(selected.serialize(SerializerFactory.get()));
         // Make sure a new UUID is asssigned for duplicate
         duplicate.setUuid(null);
         this.addBookmark(duplicate);
@@ -1900,7 +1900,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
             if(null == selected || !selected.isDirectory()) {
                 selected = workdir;
             }
-            bookmark = new HostDictionary().deserialize(pool.getHost().serialize(SerializerFactory.get()));
+            bookmark = new HostDictionary<>().deserialize(pool.getHost().serialize(SerializerFactory.get()));
             // Make sure a new UUID is asssigned for duplicate
             bookmark.setUuid(null);
             bookmark.setDefaultPath(selected.getAbsolute());
@@ -2280,7 +2280,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
             selected = workdir;
         }
         final BrowserController c = MainController.newDocument(true);
-        final Host duplicate = new HostDictionary().deserialize(pool.getHost().serialize(SerializerFactory.get()));
+        final Host duplicate = new HostDictionary<>().deserialize(pool.getHost().serialize(SerializerFactory.get()));
         // Make sure a new UUID is assigned for duplicate
         duplicate.setUuid(null);
         duplicate.setDefaultPath(selected.getAbsolute());

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/DefaultBookmarkController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/DefaultBookmarkController.java
@@ -149,9 +149,28 @@ public class DefaultBookmarkController extends BookmarkController {
     public void setPasswordField(final NSSecureTextField f) {
         super.setPasswordField(f);
         this.notificationCenter.addObserver(this.id(),
-            Foundation.selector("passwordFieldTextDidEndEditing:"),
-            NSControl.NSControlTextDidEndEditingNotification,
-            f.id());
+                Foundation.selector("passwordFieldTextDidEndEditing:"),
+                NSControl.NSControlTextDidEndEditingNotification,
+                f.id());
+        f.removeFromSuperview();
+    }
+
+    @Override
+    public void setPasswordLabel(final NSTextField l) {
+        super.setPasswordLabel(l);
+        l.removeFromSuperview();
+    }
+
+    @Override
+    public void setUsernameField(final NSTextField f) {
+        super.setUsernameField(f);
+        f.removeFromSuperview();
+    }
+
+    @Override
+    public void setUsernameLabel(final NSTextField l) {
+        super.setUsernameLabel(l);
+        l.removeFromSuperview();
     }
 
     @Action
@@ -189,7 +208,7 @@ public class DefaultBookmarkController extends BookmarkController {
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(final Host bookmark) {
-                certificatePopup.setEnabled(options.certificate);
+                certificatePopup.setHidden(!options.certificate);
                 certificatePopup.removeAllItems();
                 certificatePopup.addItemWithTitle(LocaleFactory.localizedString("None"));
                 if(options.certificate) {
@@ -239,7 +258,7 @@ public class DefaultBookmarkController extends BookmarkController {
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(final Host bookmark) {
-                timezonePopup.setEnabled(!bookmark.getProtocol().isUTCTimezone());
+                timezonePopup.setHidden(bookmark.getProtocol().isUTCTimezone());
                 if(null == bookmark.getTimezone()) {
                     if(bookmark.getProtocol().isUTCTimezone()) {
                         timezonePopup.setTitle(UTC.getID());
@@ -284,7 +303,7 @@ public class DefaultBookmarkController extends BookmarkController {
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(final Host bookmark) {
-                encodingPopup.setEnabled(bookmark.getProtocol().isEncodingConfigurable());
+                encodingPopup.setHidden(!bookmark.getProtocol().isEncodingConfigurable());
                 if(!bookmark.getProtocol().isEncodingConfigurable()) {
                     encodingPopup.selectItemWithTitle(DEFAULT);
                 }

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ExtendedBookmarkController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ExtendedBookmarkController.java
@@ -23,11 +23,13 @@ import ch.cyberduck.binding.application.NSFont;
 import ch.cyberduck.binding.application.NSImage;
 import ch.cyberduck.binding.application.NSMenuItem;
 import ch.cyberduck.binding.application.NSOpenPanel;
+import ch.cyberduck.binding.application.NSPanel;
 import ch.cyberduck.binding.application.NSPopUpButton;
 import ch.cyberduck.binding.application.NSText;
 import ch.cyberduck.binding.application.NSTextField;
 import ch.cyberduck.binding.application.NSTextFieldCell;
 import ch.cyberduck.binding.application.NSTextView;
+import ch.cyberduck.binding.application.NSWindow;
 import ch.cyberduck.binding.application.SheetCallback;
 import ch.cyberduck.binding.foundation.NSData;
 import ch.cyberduck.binding.foundation.NSNotification;
@@ -53,6 +55,7 @@ import org.rococoa.ID;
 import org.rococoa.Rococoa;
 import org.rococoa.cocoa.foundation.NSInteger;
 import org.rococoa.cocoa.foundation.NSSize;
+import org.rococoa.cocoa.foundation.NSUInteger;
 
 public class ExtendedBookmarkController extends DefaultBookmarkController {
 
@@ -83,6 +86,13 @@ public class ExtendedBookmarkController extends DefaultBookmarkController {
     public void awakeFromNib() {
         super.awakeFromNib();
         this.setState(toggleOptionsButton, preferences.getBoolean("bookmark.toggle.options"));
+    }
+
+    @Override
+    public void setWindow(final NSWindow window) {
+        window.setStyleMask(new NSUInteger(NSPanel.NSUtilityWindowMask | NSWindow.NSTitledWindowMask |
+                NSWindow.NSClosableWindowMask | NSWindow.NSResizableWindowMask));
+        super.setWindow(window);
     }
 
     @Override
@@ -131,7 +141,7 @@ public class ExtendedBookmarkController extends DefaultBookmarkController {
         this.addObserver(new BookmarkObserver() {
             @Override
             public void change(Host bookmark) {
-                connectmodePopup.setEnabled(bookmark.getProtocol().getType() == Protocol.Type.ftp);
+                connectmodePopup.setHidden(bookmark.getProtocol().getType() != Protocol.Type.ftp);
                 connectmodePopup.selectItemAtIndex(connectmodePopup.indexOfItemWithRepresentedObject(bookmark.getFTPConnectMode().name()));
             }
         });

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
@@ -1113,7 +1113,7 @@ public class MainController extends BundleController implements NSApplication.De
                 if(browser.isMounted()) {
                     // The workspace should be saved. Serialize all open browser sessions
                     final Host serialized
-                        = new HostDictionary().deserialize(browser.getSession().getHost().serialize(SerializerFactory.get()));
+                            = new HostDictionary<>().deserialize(browser.getSession().getHost().serialize(SerializerFactory.get()));
                     serialized.setWorkdir(browser.workdir());
                     sessions.add(serialized);
                     browser.window().saveFrameUsingName(serialized.getUuid());

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
@@ -38,8 +38,6 @@ import ch.cyberduck.core.ProtocolFactory;
 import ch.cyberduck.core.ProviderHelpServiceFactory;
 import ch.cyberduck.core.exception.BackgroundException;
 import ch.cyberduck.core.local.BrowserLauncherFactory;
-import ch.cyberduck.core.preferences.Preferences;
-import ch.cyberduck.core.preferences.PreferencesFactory;
 import ch.cyberduck.core.profiles.LocalProfileDescription;
 import ch.cyberduck.core.profiles.ProfileDescription;
 import ch.cyberduck.core.profiles.ProfilesFinder;
@@ -72,7 +70,6 @@ public class ProfilesPreferencesController extends BundleController {
     private final ProtocolFactory protocols = ProtocolFactory.get();
 
     private final NSNotificationCenter notificationCenter = NSNotificationCenter.defaultCenter();
-    private final Preferences preferences = PreferencesFactory.get();
 
     /**
      * Synchronized ist of available profiles

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
@@ -439,7 +439,8 @@ public class ProfilesPreferencesController extends BundleController {
             if(enabled) {
                 final Optional<Local> file = description.getFile();
                 // Update with last version from repository
-                file.ifPresent(local -> repository.put(new LocalProfileDescription(protocols.register(local)), profile));
+                file.ifPresent(local -> repository.put(new LocalProfileDescription(protocols, ProtocolFactory.BUNDLED_PROFILE_PREDICATE,
+                        protocols.register(local)), profile));
             }
             else {
                 final Optional<Profile> profile = description.getProfile();

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/ProfilesPreferencesController.java
@@ -47,7 +47,6 @@ import ch.cyberduck.core.profiles.ProfilesSynchronizeWorker;
 import ch.cyberduck.core.profiles.ProfilesWorkerBackgroundAction;
 import ch.cyberduck.core.profiles.SearchProfilePredicate;
 import ch.cyberduck.core.resources.IconCacheFactory;
-import ch.cyberduck.core.serializer.impl.dd.ProfilePlistReader;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -164,7 +163,6 @@ public class ProfilesPreferencesController extends BundleController {
     public void awakeFromNib() {
         try {
             progressIndicator.startAnimation(null);
-            final ProfilePlistReader reader = new ProfilePlistReader(protocols);
             this.background(new ProfilesWorkerBackgroundAction(this,
                 new ProfilesSynchronizeWorker(protocols, ProfilesFinder.Visitor.Prefetch) {
                     @Override

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/datasource/BookmarkTableDataSource.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/datasource/BookmarkTableDataSource.java
@@ -413,7 +413,7 @@ public class BookmarkTableDataSource extends ListDataSource {
             if(info.draggingSourceOperationMask().intValue() == NSDraggingInfo.NSDragOperationCopy.intValue()) {
                 List<Host> duplicates = new ArrayList<Host>();
                 for(Host bookmark : pasteboard) {
-                    final Host duplicate = new HostDictionary().deserialize(bookmark.serialize(SerializerFactory.get()));
+                    final Host duplicate = new HostDictionary<>().deserialize(bookmark.serialize(SerializerFactory.get()));
                     // Make sure a new UUID is assigned for duplicate
                     duplicate.setUuid(null);
                     source.add(row.intValue(), duplicate);


### PR DESCRIPTION
Allows connection profile in iterate-ch/profiles#1 to load properly with OAuth settings inherited from default bundled profile.