### PR TITLE
Get rid of confusing exception log entries such as:

### DIFF
--- a/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateApiClient.java
+++ b/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateApiClient.java
@@ -27,8 +27,13 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.GenericType;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class StoregateApiClient extends ApiClient {
+
+    static {
+        Logger.getLogger("org.glassfish.jersey.client.ClientExecutorProvidersConfigurator").setLevel(java.util.logging.Level.SEVERE);
+    }
 
     private final CloseableHttpClient client;
 


### PR DESCRIPTION
```
2022-08-01 22:44:00,666 [Thread-54] DEBUG org.glassfish.jersey.client.ClientExecutorProvidersConfigurator - null
java.lang.reflect.InvocationTargetException: null
	at java.lang.reflect.Method.invoke(Method.java:486) ~[?:1.8.0]
	at org.glassfish.jersey.client.ClientExecutorProvidersConfigurator.lookupManagedScheduledExecutorService(ClientExecutorProvidersConfigurator.java:171) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientExecutorProvidersConfigurator.init(ClientExecutorProvidersConfigurator.java:122) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientConfig$State.initRuntime(ClientConfig.java:460) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientConfig$State$$Lambda$0/66644953.get(Unknown Source) ~[?:?]
	at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(Values.java:317) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientConfig.getRuntime(ClientConfig.java:820) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientRequest.getClientRuntime(ClientRequest.java:176) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.ClientRequest.getInjectionManager(ClientRequest.java:567) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.JerseyWebTarget.onBuilder(JerseyWebTarget.java:371) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:199) ~[Cyberduck.Protocols.DLL:?]
	at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:38) ~[Cyberduck.Protocols.DLL:?]
	at ch.cyberduck.core.brick.io.swagger.client.ApiClient.invokeAPI(ApiClient.java:675) ~[Cyberduck.Protocols.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.brick.BrickApiClient.invokeAPI(BrickApiClient.java:65) ~[Cyberduck.Protocols.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.brick.io.swagger.client.api.FoldersApi.foldersListForPath(FoldersApi.java:89) ~[Cyberduck.Protocols.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.brick.BrickListService.list(BrickListService.java:56) ~[Cyberduck.Protocols.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.brick.BrickListService.list(BrickListService.java:46) ~[Cyberduck.Protocols.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.shared.ListFilteringFeature.search(ListFilteringFeature.java:47) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.shared.DefaultFindFeature.find(DefaultFindFeature.java:45) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.CachingFindFeature.find(CachingFindFeature.java:56) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.features.Find.find(Find.java:26) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.transfer.upload.AbstractUploadFilter.prepare(AbstractUploadFilter.java:123) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.iterate.mountainduck.io.SequentialWriteStrategy$1.run(SequentialWriteStrategy.java:136) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.io.SequentialWriteStrategy$1.run(SequentialWriteStrategy.java:110) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.cyberduck.core.threading.WorkerBackgroundAction.run(WorkerBackgroundAction.java:78) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction.run(SessionBackgroundAction.java:126) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction$1.call(SessionBackgroundAction.java:108) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.DefaultRetryCallable.call(DefaultRetryCallable.java:52) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction.call(SessionBackgroundAction.java:110) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.BackgroundCallable.run(BackgroundCallable.java:95) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.BackgroundCallable.call(BackgroundCallable.java:59) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.iterate.mountainduck.threading.BlockingWorkerExecutor.run(BlockingWorkerExecutor.java:76) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.DefaultFilesystemSessionPool.await(DefaultFilesystemSessionPool.java:132) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.io.SequentialWriteStrategy.write(SequentialWriteStrategy.java:110) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.io.DelegatingWriteStrategy.write(DelegatingWriteStrategy.java:125) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.SessionFilesystemOperations.write(SessionFilesystemOperations.java:837) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.SessionFilesystemOperations$2.run(SessionFilesystemOperations.java:799) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.SessionFilesystemOperations$2.run(SessionFilesystemOperations.java:795) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.cyberduck.core.threading.WorkerBackgroundAction.run(WorkerBackgroundAction.java:78) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction.run(SessionBackgroundAction.java:126) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction$1.call(SessionBackgroundAction.java:108) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.DefaultRetryCallable.call(DefaultRetryCallable.java:52) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.SessionBackgroundAction.call(SessionBackgroundAction.java:110) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.BackgroundCallable.run(BackgroundCallable.java:95) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.cyberduck.core.threading.BackgroundCallable.call(BackgroundCallable.java:59) ~[Cyberduck.Core.DLL:1d11f0180730e0fd1515a967fbf0fdf26d5248a6]
	at ch.iterate.mountainduck.threading.BlockingWorkerExecutor.run(BlockingWorkerExecutor.java:76) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.DefaultFilesystemSessionPool.await(DefaultFilesystemSessionPool.java:132) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.DefaultFilesystemSessionPool.await(DefaultFilesystemSessionPool.java:127) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.SessionFilesystemOperations.write(SessionFilesystemOperations.java:795) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.FailFastFilesystemOperations.write(FailFastFilesystemOperations.java:169) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at ch.iterate.mountainduck.fs.ProxyFilesystemOperations.write(ProxyFilesystemOperations.java:201) ~[Mountainduck.Core.DLL:70d4e95f08521ed5a5ad116e6d75bfc0a51fc9ef]
	at cli.Ch.Iterate.Mountainduck.Fs.Cbfs.CBFSFilesystem.CbFsWriteFile(Unknown Source) ~[Mountainduck.Cbfs.DLL:?]
	at cli.callback.CBFSConnect.Cbfs.FireWriteFile(Unknown Source) ~[callback.CBFSConnect.DLL:?]
	at cli.cbc200K.VP.i(Unknown Source) ~[callback.CBFSConnect.DLL:?]
Caused by: javax.naming.NoInitialContextException: Need to specify class name in environment or system property, or as an applet parameter, or in an application resource file:  java.naming.factory.initial
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:673) ~[?:1.8.0]
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313) ~[?:1.8.0]
	at javax.naming.InitialContext.getURLOrDefaultInitCtx(InitialContext.java:350) ~[?:1.8.0]
	at javax.naming.InitialContext.lookup(InitialContext.java:417) ~[?:1.8.0]
	... 54 more
```