### PR TITLE
Prioritise password authentication if one is set.

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -308,7 +308,12 @@ public class SFTPSession extends Session<SSHClient> {
         }
         defaultMethods.add(new SFTPPublicKeyAuthentication(client));
         defaultMethods.add(new SFTPChallengeResponseAuthentication(client));
-        defaultMethods.add(new SFTPPasswordAuthentication(client));
+        if(host.getCredentials().isPasswordAuthentication()) {
+            defaultMethods.add(0, new SFTPPasswordAuthentication(client));
+        }
+        else {
+            defaultMethods.add(new SFTPPasswordAuthentication(client));
+        }
         final LinkedHashMap<String, List<AuthenticationProvider<Boolean>>> methodsMap = new LinkedHashMap<>();
         defaultMethods.forEach(m -> methodsMap.computeIfAbsent(m.getMethod(), k -> new ArrayList<>()).add(m));
         final List<AuthenticationProvider<Boolean>> methods = new ArrayList<>();

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -308,7 +308,7 @@ public class SFTPSession extends Session<SSHClient> {
         }
         defaultMethods.add(new SFTPPublicKeyAuthentication(client));
         defaultMethods.add(new SFTPChallengeResponseAuthentication(client));
-        if(host.getCredentials().isPasswordAuthentication()) {
+        if(credentials.isPasswordAuthentication()) {
             defaultMethods.add(0, new SFTPPasswordAuthentication(client));
         }
         else {


### PR DESCRIPTION
Reduces number of authentications if an explicit password is set. Fixes #13442. Relates to #13680 to minimize authentication attempts.