### PR TITLE
Check directory for existence as on .NET with IKVM a generic IOExcept…

### DIFF
--- a/nio/src/main/java/ch/cyberduck/core/nio/LocalListService.java
+++ b/nio/src/main/java/ch/cyberduck/core/nio/LocalListService.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.EnumSet;
 
 public class LocalListService implements ListService {
@@ -44,7 +45,12 @@ public class LocalListService implements ListService {
     @Override
     public AttributedList<Path> list(final Path directory, final ListProgressListener listener) throws BackgroundException {
         final AttributedList<ch.cyberduck.core.Path> paths = new AttributedList<>();
-        try (DirectoryStream<java.nio.file.Path> stream = Files.newDirectoryStream(session.toPath(directory))) {
+        final java.nio.file.Path p = session.toPath(directory);
+        if(!Files.exists(p)) {
+            throw new LocalExceptionMappingService().map("Listing directory {0} failed",
+                    new NoSuchFileException(directory.getAbsolute()), directory);
+        }
+        try (DirectoryStream<java.nio.file.Path> stream = Files.newDirectoryStream(p)) {
             for(java.nio.file.Path n : stream) {
                 if(null == n.getFileName()) {
                     continue;


### PR DESCRIPTION
…ion is thrown in case we want to open a stream with a non-existent path.