### PR TITLE
Partially revert f5a537a9fb608ccc299896300f66670b755adea3. As the com…

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/OpenSSHAgentAuthenticator.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/openssh/OpenSSHAgentAuthenticator.java
@@ -58,10 +58,6 @@ public class OpenSSHAgentAuthenticator extends AgentAuthenticator {
             log.warn("Missing proxy reference");
             return Collections.emptyList();
         }
-        if(!proxy.isRunning()) {
-            log.warn(String.format("Agent %s not running", this));
-            return Collections.emptyList();
-        }
         if(log.isDebugEnabled()) {
             log.debug(String.format("Retrieve identities from proxy %s", proxy));
         }

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/putty/PageantAuthenticator.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/putty/PageantAuthenticator.java
@@ -61,10 +61,6 @@ public class PageantAuthenticator extends AgentAuthenticator {
             log.warn("Missing proxy reference");
             return Collections.emptyList();
         }
-        if(!proxy.isRunning()) {
-            log.warn(String.format("Agent %s not running", this));
-            return Collections.emptyList();
-        }
         if(log.isDebugEnabled()) {
             log.debug(String.format("Retrieve identities from proxy %s", proxy));
         }


### PR DESCRIPTION
…munication with the agent works differently on Windows the check if it is running does not work. The check is not necessary as the identity retrieval fails if the agent is not running and returns an empty collection.

Fixes #14257.