### PR TITLE
Review Windows PromptForm-dialogs

### DIFF
--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateFilePromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateFilePromptForm.cs
@@ -59,7 +59,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 2,
                 Text = "Cancel",
             }, out var cancelButton), 3, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateFilePromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateFilePromptForm.cs
@@ -16,10 +16,9 @@
 // yves@cyberduck.ch
 // 
 
-using System.Drawing;
-using System.Windows.Forms;
-using Ch.Cyberduck.Ui.Controller;
 using ch.cyberduck.core;
+using Ch.Cyberduck.Ui.Controller;
+using System.Windows.Forms;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
@@ -30,26 +29,42 @@ namespace Ch.Cyberduck.Ui.Winforms
             InitializeComponent();
 
             Text = LocaleFactory.localizedString("Create new file", "File");
-            Button cancelBtn = new Button
-                {
-                    AutoSize = true,
-                    Size = new Size(75, okButton.Size.Height),
-                    TabIndex = 5,
-                    Text = LocaleFactory.localizedString("Cancel"),
-                    UseVisualStyleBackColor = true,
-                    Anchor = AnchorStyles.Bottom | AnchorStyles.Left
-                };
-            tableLayoutPanel.Controls.Add(cancelBtn, 1, 2);
-
             pictureBox.Padding = new Padding(0, 0, 0, 5);
             label.Text = LocaleFactory.localizedString("Enter the name for the new file", "File");
-            okButton.Text = LocaleFactory.localizedString("Create", "File");
 
-            // cancelButton is the 'Edit' button now
-            cancelButton.DialogResult = DialogResult.Yes;
-            cancelButton.Text = LocaleFactory.localizedString("Edit", "File");
+            SetupButtons();
+        }
+        
+        private void SetupButtons()
+        {
+            buttonPanel.SuspendLayout();
 
-            CancelButton = cancelBtn;
+            buttonPanel.ColumnCount = 4;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = LocaleFactory.localizedString("Create", "File"),
+            }, out var createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Yes,
+                TabIndex = 1,
+                Text = LocaleFactory.localizedString("Edit", "File"),
+            }, out _), 2, 0);
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 3, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateSymlinkPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateSymlinkPromptForm.cs
@@ -60,7 +60,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 1,
                 Text = "Cancel",
             }, out var cancelButton), 2, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateSymlinkPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/CreateSymlinkPromptForm.cs
@@ -16,9 +16,10 @@
 // yves@cyberduck.ch
 // 
 
-using System;
-using Ch.Cyberduck.Ui.Controller;
 using ch.cyberduck.core;
+using Ch.Cyberduck.Ui.Controller;
+using System;
+using System.Windows.Forms;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
@@ -28,6 +29,8 @@ namespace Ch.Cyberduck.Ui.Winforms
         {
             InitializeComponent();
             Text = LocaleFactory.localizedString("Create new symbolic link", "File");
+
+            SetupButtons();
         }
 
         public string LinkForFile
@@ -39,6 +42,30 @@ namespace Ch.Cyberduck.Ui.Winforms
                         LocaleFactory.localizedString("Enter the name for the new symbolic link for {0}:", "File"),
                         value);
             }
+        }
+
+        private void SetupButtons()
+        {
+            buttonPanel.SuspendLayout();
+
+            buttonPanel.ColumnCount = 3;
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = "Create"
+            }, out var createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 2, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/DuplicateFilePromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/DuplicateFilePromptForm.cs
@@ -52,7 +52,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 1,
                 Text = "Cancel",
             }, out var cancelButton), 2, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/DuplicateFilePromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/DuplicateFilePromptForm.cs
@@ -16,8 +16,9 @@
 // yves@cyberduck.ch
 // 
 
-using Ch.Cyberduck.Ui.Controller;
 using ch.cyberduck.core;
+using Ch.Cyberduck.Ui.Controller;
+using System.Windows.Forms;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
@@ -31,8 +32,32 @@ namespace Ch.Cyberduck.Ui.Winforms
 
             pictureBox.Width = 32;
             label.Text = LocaleFactory.localizedString("Enter the name for the new file", "Duplicate");
-            okButton.Text = LocaleFactory.localizedString("Duplicate", "Duplicate");
-            cancelButton.Text = LocaleFactory.localizedString("Cancel", "Duplicate");
+
+            SetupButtons();
+        }
+
+        private void SetupButtons()
+        {
+            buttonPanel.SuspendLayout();
+
+            buttonPanel.ColumnCount = 3;
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = LocaleFactory.localizedString("Duplicate", "Duplicate"),
+            }, out var createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 2, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/GotoPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/GotoPromptForm.cs
@@ -16,9 +16,9 @@
 // yves@cyberduck.ch
 // 
 
-using System.Windows.Forms;
-using Ch.Cyberduck.Ui.Controller;
 using ch.cyberduck.core;
+using Ch.Cyberduck.Ui.Controller;
+using System.Windows.Forms;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
@@ -32,7 +32,32 @@ namespace Ch.Cyberduck.Ui.Winforms
             pictureBox.Padding = new Padding(0, 0, 0, 5);
 
             label.Text = LocaleFactory.localizedString("Enter the pathname to list:", "Goto");
-            okButton.Text = LocaleFactory.localizedString("Go", "Goto");
+
+            SetupButtons();
+        }
+
+        private void SetupButtons()
+        {
+            buttonPanel.SuspendLayout();
+
+            buttonPanel.ColumnCount = 3;
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = LocaleFactory.localizedString("Go", "Goto"),
+            }, out var createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 2, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/GotoPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/GotoPromptForm.cs
@@ -52,7 +52,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 1,
                 Text = "Cancel",
             }, out var cancelButton), 2, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewFolderPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewFolderPromptForm.cs
@@ -57,7 +57,7 @@ namespace Ch.Cyberduck.Ui.Winforms
                     regionComboBox.Margin = new(6);
                     regionComboBox.Name = "regionComboBox";
                     regionComboBox.Size = new Size(121, 23);
-                    regionComboBox.TabIndex = 3;
+                    regionComboBox.TabIndex = 1;
 
                     tableLayoutPanel.Controls.Add(regionComboBox, 1, regionRow);
                 }
@@ -95,7 +95,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.OK,
-                TabIndex = 0,
+                TabIndex = 16,
                 Text = "Create"
             }, out var createButton), 1, 0);
             AcceptButton = createButton;
@@ -103,7 +103,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 17,
                 Text = "Cancel",
             }, out var cancelButton), 2, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewFolderPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewFolderPromptForm.cs
@@ -16,20 +16,32 @@
 // feedback@cyberduck.io
 // 
 
+using Ch.Cyberduck.Ui.Controller;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
-using Ch.Cyberduck.Ui.Controller;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
     public partial class NewFolderPromptForm : PromptForm, INewFolderPromptView
     {
+        private readonly int regionRow;
         private ComboBox regionComboBox;
 
         public NewFolderPromptForm()
         {
             InitializeComponent();
+
+            tableLayoutPanel.SuspendLayout();
+
+            var newButtonRow = tableLayoutPanel.RowCount++;
+            regionRow = newButtonRow - 1;
+            tableLayoutPanel.RowStyles.Insert(regionRow, new());
+            tableLayoutPanel.SetRow(buttonPanel, newButtonRow);
+
+            SetupButtons();
+
+            tableLayoutPanel.ResumeLayout();
         }
 
         public bool RegionsEnabled
@@ -39,19 +51,15 @@ namespace Ch.Cyberduck.Ui.Winforms
                 if (value && regionComboBox == null)
                 {
                     regionComboBox = new ComboBox();
+                    regionComboBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
+                    regionComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
                     regionComboBox.FormattingEnabled = true;
-                    regionComboBox.Location = new Point(84, 70);
+                    regionComboBox.Margin = new(6);
                     regionComboBox.Name = "regionComboBox";
                     regionComboBox.Size = new Size(121, 23);
-                    regionComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
                     regionComboBox.TabIndex = 3;
-                    regionComboBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
-                    tableLayoutPanel.RowCount++;
-                    tableLayoutPanel.RowStyles.Insert(2, new RowStyle(SizeType.AutoSize));
-                    tableLayoutPanel.SetRow(okButton, 3);
-                    tableLayoutPanel.SetRow(cancelButton, 3);
-                    tableLayoutPanel.Controls.Add(regionComboBox, 1, 2);
-                    tableLayoutPanel.SetColumnSpan(regionComboBox, 3);
+
+                    tableLayoutPanel.Controls.Add(regionComboBox, 1, regionRow);
                 }
             }
             protected get { return regionComboBox != null; }
@@ -59,7 +67,7 @@ namespace Ch.Cyberduck.Ui.Winforms
 
         public string Region
         {
-            get { return regionComboBox != null ? (string) regionComboBox.SelectedValue : null; }
+            get { return regionComboBox != null ? (string)regionComboBox.SelectedValue : null; }
             set
             {
                 if (regionComboBox != null)
@@ -77,6 +85,30 @@ namespace Ch.Cyberduck.Ui.Winforms
                 regionComboBox.ValueMember = "Key";
                 regionComboBox.DisplayMember = "Value";
             }
+        }
+
+        protected void SetupButtons()
+        {
+            buttonPanel.SuspendLayout();
+
+            buttonPanel.ColumnCount = 3;
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = "Create"
+            }, out var createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 2, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewVaultPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewVaultPromptForm.cs
@@ -50,6 +50,7 @@ namespace Ch.Cyberduck.Ui.Winforms
                 Dock = DockStyle.Fill,
                 GrowStyle = TableLayoutPanelGrowStyle.FixedSize,
                 RowCount = 3,
+                TabIndex = 2,
             };
             tableLayoutPanel.RowStyles.Insert(layoutRow, new());
             tableLayoutPanel.Controls.Add(passphraseLayout, 1, layoutRow);
@@ -66,8 +67,8 @@ namespace Ch.Cyberduck.Ui.Winforms
             passphraseTextBox = new TextBox();
             passphraseTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
             passphraseTextBox.Name = "passphraseTextBox";
+            passphraseTextBox.TabIndex = 0;
             passphraseTextBox.UseSystemPasswordChar = true;
-            passphraseTextBox.TabIndex = 4;
             passphraseTextBox.TextChanged += delegate (object sender, EventArgs args)
             {
                 PasswordStrengthValidator.Strength strength = strengthValidator.getScore(passphraseTextBox.Text);
@@ -87,8 +88,8 @@ namespace Ch.Cyberduck.Ui.Winforms
             passphraseConfirmTextBox = new TextBox();
             passphraseConfirmTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
             passphraseConfirmTextBox.Name = "passphraseConfirmTextBox";
+            passphraseConfirmTextBox.TabIndex = 1;
             passphraseConfirmTextBox.UseSystemPasswordChar = true;
-            passphraseConfirmTextBox.TabIndex = 4;
             passphraseLayout.Controls.Add(passphraseConfirmTextBox, 0, 2);
             SendMessage((HWND)passphraseConfirmTextBox.Handle, EM_SETCUEBANNER, 0,
                 LocaleFactory.localizedString("Confirm Passphrase", "Cryptomator"));

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewVaultPromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/NewVaultPromptForm.cs
@@ -19,10 +19,9 @@
 using ch.cyberduck.core;
 using Ch.Cyberduck.Ui.Controller;
 using Ch.Cyberduck.Ui.Winforms.Controls;
-using Windows.Win32.Foundation;
 using System;
-using System.Drawing;
 using System.Windows.Forms;
+using Windows.Win32.Foundation;
 using static Windows.Win32.CorePInvoke;
 using static Windows.Win32.PInvoke;
 
@@ -30,15 +29,32 @@ namespace Ch.Cyberduck.Ui.Winforms
 {
     public partial class NewVaultPromptForm : NewFolderPromptForm, INewVaultPromptView
     {
-        private readonly PasswordStrengthValidator strengthValidator = new PasswordStrengthValidator();
+        private readonly TableLayoutPanel passphraseLayout;
+        private readonly PasswordStrengthValidator strengthValidator = new();
         private TextBox passphraseConfirmTextBox;
-        private Label passphraseLabel;
         private TextBox passphraseTextBox;
         private PasswordStrengthIndicator strengthIndicator;
 
         public NewVaultPromptForm()
         {
             InitializeComponent();
+
+            tableLayoutPanel.SuspendLayout();
+
+            var buttonRow = tableLayoutPanel.RowCount++;
+            var layoutRow = buttonRow - 1;
+            tableLayoutPanel.SetRow(buttonPanel, buttonRow);
+            passphraseLayout = new TableLayoutPanel()
+            {
+                ColumnCount = 1,
+                Dock = DockStyle.Fill,
+                GrowStyle = TableLayoutPanelGrowStyle.FixedSize,
+                RowCount = 3,
+            };
+            tableLayoutPanel.RowStyles.Insert(layoutRow, new());
+            tableLayoutPanel.Controls.Add(passphraseLayout, 1, layoutRow);
+
+            tableLayoutPanel.ResumeLayout();
         }
 
         public string Passphrase => passphraseTextBox.Text;
@@ -47,53 +63,34 @@ namespace Ch.Cyberduck.Ui.Winforms
 
         public void EnablePassphrase()
         {
-            int offset = RegionsEnabled ? 1 : 0;
             passphraseTextBox = new TextBox();
-            passphraseTextBox.Location = new Point(84, 70);
+            passphraseTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
             passphraseTextBox.Name = "passphraseTextBox";
-            passphraseTextBox.Size = new Size(121, 23);
-            passphraseTextBox.Margin = new Padding(6);
             passphraseTextBox.UseSystemPasswordChar = true;
             passphraseTextBox.TabIndex = 4;
-            passphraseTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
-            passphraseTextBox.TextChanged += delegate(object sender, EventArgs args)
+            passphraseTextBox.TextChanged += delegate (object sender, EventArgs args)
             {
                 PasswordStrengthValidator.Strength strength = strengthValidator.getScore(passphraseTextBox.Text);
                 strengthIndicator.Minimum = PasswordStrengthValidator.Strength.veryweak.getScore();
                 strengthIndicator.Maximum = PasswordStrengthValidator.Strength.verystrong.getScore() + 1;
                 strengthIndicator.Value = strength.getScore() + 1;
             };
-            tableLayoutPanel.RowCount++;
-            tableLayoutPanel.RowStyles.Insert(2 + offset, new RowStyle(SizeType.AutoSize));
-            tableLayoutPanel.Controls.Add(passphraseTextBox, 1, 2 + offset);
-            tableLayoutPanel.SetColumnSpan(passphraseTextBox, 3);
-            SendMessage((HWND)passphraseTextBox.Handle, EM_SETCUEBANNER, 0, 
+            passphraseLayout.Controls.Add(passphraseTextBox, 0, 0);
+            SendMessage((HWND)passphraseTextBox.Handle, EM_SETCUEBANNER, 0,
                 LocaleFactory.localizedString("Passphrase", "Cryptomator Key"));
 
             strengthIndicator = new PasswordStrengthIndicator();
             strengthIndicator.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
-            strengthIndicator.Margin = new Padding(6);
-            tableLayoutPanel.RowCount++;
-            tableLayoutPanel.RowStyles.Insert(3 + offset, new RowStyle(SizeType.AutoSize));
-            tableLayoutPanel.Controls.Add(strengthIndicator, 1, 3 + offset);
-            tableLayoutPanel.SetColumnSpan(strengthIndicator, 3);
             strengthIndicator.Value = 0;
+            passphraseLayout.Controls.Add(strengthIndicator, 0, 1);
 
             passphraseConfirmTextBox = new TextBox();
-            passphraseConfirmTextBox.Location = new Point(84, 70);
+            passphraseConfirmTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
             passphraseConfirmTextBox.Name = "passphraseConfirmTextBox";
-            passphraseConfirmTextBox.Size = new Size(121, 23);
-            passphraseConfirmTextBox.Margin = new Padding(6);
             passphraseConfirmTextBox.UseSystemPasswordChar = true;
             passphraseConfirmTextBox.TabIndex = 4;
-            passphraseConfirmTextBox.Anchor = (((AnchorStyles.Left | AnchorStyles.Right)));
-            tableLayoutPanel.RowCount++;
-            tableLayoutPanel.RowStyles.Insert(4 + offset, new RowStyle(SizeType.AutoSize));
-            tableLayoutPanel.Controls.Add(passphraseConfirmTextBox, 1, 4 + offset);
-            tableLayoutPanel.SetColumnSpan(passphraseConfirmTextBox, 3);
-            tableLayoutPanel.SetRow(okButton, 5 + offset);
-            tableLayoutPanel.SetRow(cancelButton, 5 + offset);
-            SendMessage((HWND)passphraseConfirmTextBox.Handle, EM_SETCUEBANNER, 0, 
+            passphraseLayout.Controls.Add(passphraseConfirmTextBox, 0, 2);
+            SendMessage((HWND)passphraseConfirmTextBox.Handle, EM_SETCUEBANNER, 0,
                 LocaleFactory.localizedString("Confirm Passphrase", "Cryptomator"));
         }
     }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/PasswordForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/PasswordForm.cs
@@ -43,7 +43,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             saveCheckBox = new CheckBox
             {
                 Name = "saveCheckBox",
-                TabIndex = 3,
+                TabIndex = 1,
                 Anchor = (((AnchorStyles.Left | AnchorStyles.Right))),
                 Text = "Save Password"
             };
@@ -98,7 +98,7 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.OK,
-                TabIndex = 0,
+                TabIndex = 16,
                 Text = "Create",
             }, out createButton), 1, 0);
             AcceptButton = createButton;
@@ -106,14 +106,14 @@ namespace Ch.Cyberduck.Ui.Winforms
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Yes,
-                TabIndex = 1,
+                TabIndex = 17,
                 Text = "Skip",
             }, out skipButton), 2, 0);
 
             buttonPanel.Controls.Add(CreateButton(new Button()
             {
                 DialogResult = DialogResult.Cancel,
-                TabIndex = 5,
+                TabIndex = 18,
                 Text = "Cancel",
             }, out var cancelButton), 3, 0);
             CancelButton = cancelButton;

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/PasswordForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/PasswordForm.cs
@@ -16,20 +16,30 @@
 // feedback@cyberduck.io
 // 
 
-using System.Windows.Forms;
 using Ch.Cyberduck.Ui.Controller;
+using System.Windows.Forms;
 
 namespace Ch.Cyberduck.Ui.Winforms
 {
     public partial class PasswordForm : PromptForm, IPasswordPromptView
     {
         private readonly CheckBox saveCheckBox;
+        private readonly Button okButton;
+        private readonly Button skipButton;
 
         public PasswordForm()
         {
             InitializeComponent();
 
             inputTextBox.UseSystemPasswordChar = true;
+            
+            tableLayoutPanel.SuspendLayout();
+
+            var lastRow = tableLayoutPanel.RowCount++;
+            var layoutRow = lastRow - 1;
+            tableLayoutPanel.RowStyles.Insert(layoutRow, new(SizeType.AutoSize));
+            tableLayoutPanel.SetRow(buttonPanel, lastRow);
+
             saveCheckBox = new CheckBox
             {
                 Name = "saveCheckBox",
@@ -37,12 +47,11 @@ namespace Ch.Cyberduck.Ui.Winforms
                 Anchor = (((AnchorStyles.Left | AnchorStyles.Right))),
                 Text = "Save Password"
             };
-            tableLayoutPanel.RowStyles.Insert(2, new RowStyle(SizeType.AutoSize));
-            tableLayoutPanel.SetRow(okButton, 3);
-            tableLayoutPanel.SetRow(cancelButton, 3);
-            tableLayoutPanel.SetRow(skipButton, 3);
-            tableLayoutPanel.Controls.Add(saveCheckBox, 1, 2);
-            tableLayoutPanel.SetColumnSpan(saveCheckBox, 3);
+            tableLayoutPanel.Controls.Add(saveCheckBox, 1, layoutRow);
+
+            SetupButtons(out okButton, out skipButton);
+
+            tableLayoutPanel.ResumeLayout();
         }
 
         public bool CanSkip
@@ -79,6 +88,37 @@ namespace Ch.Cyberduck.Ui.Winforms
         public string SkipButtonText
         {
             set => skipButton.Text = value;
+        }
+
+        private void SetupButtons(out Button createButton, out Button skipButton)
+        {
+            buttonPanel.SuspendLayout();
+
+            buttonPanel.ColumnCount = 4;
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.OK,
+                TabIndex = 0,
+                Text = "Create",
+            }, out createButton), 1, 0);
+            AcceptButton = createButton;
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Yes,
+                TabIndex = 1,
+                Text = "Skip",
+            }, out skipButton), 2, 0);
+
+            buttonPanel.Controls.Add(CreateButton(new Button()
+            {
+                DialogResult = DialogResult.Cancel,
+                TabIndex = 5,
+                Text = "Cancel",
+            }, out var cancelButton), 3, 0);
+            CancelButton = cancelButton;
+
+            buttonPanel.ResumeLayout();
         }
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.Designer.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.Designer.cs
@@ -61,7 +61,7 @@
             this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
             this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel.Size = new System.Drawing.Size(462, 133);
-            this.tableLayoutPanel.TabIndex = 4;
+            this.tableLayoutPanel.TabIndex = 0;
             // 
             // pictureBox
             // 
@@ -72,7 +72,6 @@
             this.tableLayoutPanel.SetRowSpan(this.pictureBox, 2);
             this.pictureBox.Size = new System.Drawing.Size(75, 55);
             this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
-            this.pictureBox.TabIndex = 0;
             this.pictureBox.TabStop = false;
             // 
             // label
@@ -82,7 +81,6 @@
             this.label.Location = new System.Drawing.Point(90, 20);
             this.label.Name = "label";
             this.label.Size = new System.Drawing.Size(184, 15);
-            this.label.TabIndex = 1;
             this.label.Text = "Enter the name for the new folder";
             // 
             // inputTextBox
@@ -92,7 +90,7 @@
             this.inputTextBox.Margin = new System.Windows.Forms.Padding(6);
             this.inputTextBox.Name = "inputTextBox";
             this.inputTextBox.Size = new System.Drawing.Size(363, 23);
-            this.inputTextBox.TabIndex = 2;
+            this.inputTextBox.TabIndex = 0;
             // 
             // buttonPanel
             // 
@@ -106,7 +104,7 @@
             this.buttonPanel.RowCount = 1;
             this.buttonPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.buttonPanel.Size = new System.Drawing.Size(375, 66);
-            this.buttonPanel.TabIndex = 3;
+            this.buttonPanel.TabIndex = 16;
             // 
             // PromptForm
             // 

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.Designer.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.Designer.cs
@@ -28,58 +28,31 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.okButton = new System.Windows.Forms.Button();
-            this.cancelButton = new System.Windows.Forms.Button();
             this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.pictureBox = new System.Windows.Forms.PictureBox();
             this.label = new System.Windows.Forms.Label();
             this.inputTextBox = new System.Windows.Forms.TextBox();
-            this.skipButton = new System.Windows.Forms.Button();
+            this.buttonPanel = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
             this.SuspendLayout();
-            // 
-            // okButton
-            // 
-            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.okButton.AutoSize = true;
-            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(198, 103);
-            this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(87, 27);
-            this.okButton.TabIndex = 0;
-            this.okButton.Text = "Create";
-            this.okButton.UseVisualStyleBackColor = true;
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cancelButton.AutoSize = true;
-            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(372, 103);
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(87, 27);
-            this.cancelButton.TabIndex = 1;
-            this.cancelButton.Text = "Cancel";
-            this.cancelButton.UseVisualStyleBackColor = true;
             // 
             // tableLayoutPanel
             // 
             this.tableLayoutPanel.AutoScroll = true;
             this.tableLayoutPanel.AutoSize = true;
-            this.tableLayoutPanel.ColumnCount = 5;
+            this.tableLayoutPanel.ColumnCount = 2;
             this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel.Controls.Add(this.pictureBox, 0, 0);
             this.tableLayoutPanel.Controls.Add(this.label, 1, 0);
-            this.tableLayoutPanel.Controls.Add(this.cancelButton, 4, 2);
             this.tableLayoutPanel.Controls.Add(this.inputTextBox, 1, 1);
-            this.tableLayoutPanel.Controls.Add(this.okButton, 2, 2);
-            this.tableLayoutPanel.Controls.Add(this.skipButton, 3, 2);
+            this.tableLayoutPanel.Controls.Add(this.buttonPanel, 1, 2);
             this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
             this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel.Margin = new System.Windows.Forms.Padding(6);
             this.tableLayoutPanel.Name = "tableLayoutPanel";
@@ -106,7 +79,6 @@
             // 
             this.label.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label.AutoSize = true;
-            this.tableLayoutPanel.SetColumnSpan(this.label, 4);
             this.label.Location = new System.Drawing.Point(90, 20);
             this.label.Name = "label";
             this.label.Size = new System.Drawing.Size(184, 15);
@@ -116,38 +88,38 @@
             // inputTextBox
             // 
             this.inputTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel.SetColumnSpan(this.inputTextBox, 4);
             this.inputTextBox.Location = new System.Drawing.Point(93, 41);
             this.inputTextBox.Margin = new System.Windows.Forms.Padding(6);
             this.inputTextBox.Name = "inputTextBox";
             this.inputTextBox.Size = new System.Drawing.Size(363, 23);
             this.inputTextBox.TabIndex = 2;
             // 
-            // skipButton
+            // buttonPanel
             // 
-            this.skipButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.skipButton.AutoSize = true;
-            this.skipButton.DialogResult = System.Windows.Forms.DialogResult.Ignore;
-            this.skipButton.Location = new System.Drawing.Point(291, 103);
-            this.skipButton.Name = "skipButton";
-            this.skipButton.Size = new System.Drawing.Size(75, 27);
-            this.skipButton.TabIndex = 3;
-            this.skipButton.Text = "Skip";
-            this.skipButton.UseVisualStyleBackColor = true;
+            this.buttonPanel.ColumnCount = 1;
+            this.buttonPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.buttonPanel.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.buttonPanel.Location = new System.Drawing.Point(87, 67);
+            this.buttonPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.buttonPanel.Name = "buttonPanel";
+            this.buttonPanel.RowCount = 1;
+            this.buttonPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.buttonPanel.Size = new System.Drawing.Size(375, 66);
+            this.buttonPanel.TabIndex = 3;
             // 
             // PromptForm
             // 
-            this.AcceptButton = this.okButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.CancelButton = this.cancelButton;
             this.ClientSize = new System.Drawing.Size(462, 133);
             this.Controls.Add(this.tableLayoutPanel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Margin = new System.Windows.Forms.Padding(13, 15, 13, 15);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(400, 150);
             this.Name = "PromptForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Create new folder";
@@ -165,9 +137,7 @@
         protected System.Windows.Forms.TextBox inputTextBox;
         protected System.Windows.Forms.PictureBox pictureBox;
         protected System.Windows.Forms.Label label;
-        protected System.Windows.Forms.Button okButton;
-        protected System.Windows.Forms.Button cancelButton;
         protected System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
-        protected System.Windows.Forms.Button skipButton;
+        protected System.Windows.Forms.TableLayoutPanel buttonPanel;
     }
 }

--- a/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/winforms/PromptForm.cs
@@ -29,7 +29,6 @@ namespace Ch.Cyberduck.Ui.Winforms
         public PromptForm()
         {
             InitializeComponent();
-            AutoSize = true;
             FormClosing += delegate (object sender, FormClosingEventArgs args)
             {
                 if (DialogResult == DialogResult.Cancel || DialogResult == DialogResult.Ignore)
@@ -55,8 +54,6 @@ namespace Ch.Cyberduck.Ui.Winforms
                     SystemSounds.Beep.Play();
                 }
             };
-            MinimumSize = new Size(400, 150);
-            skipButton.Visible = ValidateSkip();
         }
 
         protected override bool EnableAutoSizePosition => false;
@@ -76,12 +73,19 @@ namespace Ch.Cyberduck.Ui.Winforms
 
         public event ValidateInputHandler ValidateInput;
 
+        protected static Button CreateButton(Button button, out Button result)
+        {
+            button.AutoSize = true;
+            button.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            button.UseVisualStyleBackColor = true;
+            result = button;
+            return button;
+        }
+
         private void PromptForm_Shown(object sender, EventArgs e)
         {
             inputTextBox.Focus();
             inputTextBox.SelectAll();
         }
-
-        protected virtual bool ValidateSkip() => false;
     }
 }

--- a/windows/src/test/csharp/ch/cyberduck/ui/winforms/InteractiveUiTests.cs
+++ b/windows/src/test/csharp/ch/cyberduck/ui/winforms/InteractiveUiTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace Ch.Cyberduck.Ui.Winforms
+{
+    [Explicit("Interactive UI tests, run with user validating graphics.")]
+    [TestFixture]
+    public class InteractiveUiTests
+    {
+        [OneTimeSetUp]
+        public static void Setup()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+        }
+
+        [Test]
+        public void TestCreateFilePrompt()
+        {
+            Application.Run(new CreateFilePromptForm());
+        }
+
+        [Test]
+        public void TestCreateSymlinkPrompt()
+        {
+            Application.Run(new CreateSymlinkPromptForm());
+        }
+
+        [Test]
+        public void TestDuplicateFilePrompt()
+        {
+            Application.Run(new DuplicateFilePromptForm());
+        }
+
+        [Test]
+        public void TestGoToPromptForm()
+        {
+            Application.Run(new GotoPromptForm());
+        }
+
+        [Test]
+        public void TestNewFolderPrompt()
+        {
+            Application.Run(new NewFolderPromptForm());
+        }
+
+        [Test]
+        public void TestNewFolderRegionPrompt()
+        {
+            Application.Run(WithRegions(new NewFolderPromptForm()));
+        }
+
+        [Test]
+        public void TestNewVaultPrompt()
+        {
+            var prompt = new NewVaultPromptForm();
+            prompt.EnablePassphrase();
+            Application.Run(prompt);
+        }
+
+        [Test]
+        public void TestNewVaultBeforeRegionPrompt()
+        {
+            var prompt = new NewVaultPromptForm();
+            prompt.EnablePassphrase();
+            Application.Run(WithRegions(prompt));
+        }
+
+        [Test]
+        public void TestNewVaultAfterRegionPrompt()
+        {
+            var prompt = WithRegions(new NewVaultPromptForm());
+            prompt.EnablePassphrase();
+            Application.Run(prompt);
+        }
+
+        [Test]
+        public void TestPasswordForm()
+        {
+            Application.Run(new PasswordForm());
+        }
+
+        private static T WithRegions<T>(T @this) where T : NewFolderPromptForm
+        {
+            @this.RegionsEnabled = true;
+            @this.Region = "REGION";
+            @this.PopulateRegions(new[] { new KeyValuePair<string, string>("REGION", "Test Region") });
+            return @this;
+        }
+    }
+}


### PR DESCRIPTION
Includes interactive (non CI) tests, that need to be run explicitely - in some kind of interactive session, where developers can interact with created dialog forms.

There are ordering issues with NewVault-prompt, where regions populated before passphrase may result in corrupt layout.

- [x] Remove all fixed buttons from PromptForm
Each Prompt should create its own buttons
  - [x] Create File
  - [x] Create Symlink
  - [x] Password Prompt
  - [x] Duplicate File
  - [x] Go To
  - [x] New Vault
  - [x] New Folder
- [x] Fix layout of New Folder-prompt
- [x] Fix layout of New Vault-prompt
- [x] Review TabStop-groups