### PR TITLE
No more Fody

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,8 +32,7 @@
 
     <ItemGroup>
         <CyberduckProjectReferences Include="@(CyberduckReference->HasMetadata('ProjectPath'))" Condition=" '$(BuildingInsideVisualStudio)'=='True' " />
-        <CyberduckLibraryReferences Include="@(CyberduckReference)" />
-        <CyberduckLibraryReferences Remove="@(CyberduckProjectReferences)" />
+        <CyberduckLibraryReferences Include="@(CyberduckReference)" Exclude="@(CyberduckProjectReferences)" />
 
         <ProjectReference Include="@(CyberduckProjectReferences->'%(ProjectPath)')">
             <Name>Cyberduck.%(Identity)</Name>

--- a/Packages.props
+++ b/Packages.props
@@ -18,8 +18,6 @@
   <ItemGroup>
     <PackageReference Update="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.100" />
     <PackageReference Update="ExceptionReporter " Version="2.4.2" />
-    <PackageReference Update="Fody" Version="6.6.0" PrivateAssets="all" />
-    <PackageReference Update="InlineIL.Fody" Version="1.7.1" PrivateAssets="all" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Update="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
@@ -29,16 +27,13 @@
     <PackageReference Update="NUnit.ConsoleRunner" Version="3.16.0" GeneratePathProperty="true" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Update="ObjectListView.Official" Version="2.9.1" />
-    <PackageReference Update="ReactiveUI.Fody" Version="17.1.50" />
     <PackageReference Update="ReactiveUI.WPF" Version="17.1.50" />
     <PackageReference Update="StructureMap" Version="2.6.4.1" />
-    <PackageReference Update="System.Memory" Version="4.5.4" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Update="System.Memory" Version="4.5.5" />
 
     <!-- Build-Supports -->
     <PackageReference Update="Microsoft.Windows.CsWin32" Version="0.1.647-beta">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <GlobalPackageReference Include="MSBuildTasks" Version="1.5.0.235" GeneratePathProperty="true" />

--- a/bonjour/src/main/csharp/Cyberduck.Bonjour.Native.csproj
+++ b/bonjour/src/main/csharp/Cyberduck.Bonjour.Native.csproj
@@ -25,6 +25,7 @@
       <Lcid>0</Lcid>
       <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
     </COMReference>
   </ItemGroup>
 

--- a/cli/src/main/csharp/duck.csproj
+++ b/cli/src/main/csharp/duck.csproj
@@ -43,7 +43,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/core/native/refresh/src/main/csharp/Cyberduck.Core.Refresh.csproj
+++ b/core/native/refresh/src/main/csharp/Cyberduck.Core.Refresh.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" />
-    <PackageReference Include="ReactiveUI.Fody" />
     <PackageReference Include="ReactiveUI.WPF" />
   </ItemGroup>
 

--- a/core/native/refresh/src/main/csharp/Services/IconProvider.cs
+++ b/core/native/refresh/src/main/csharp/Services/IconProvider.cs
@@ -81,9 +81,9 @@ namespace Ch.Cyberduck.Core.Refresh.Services
                     using HICON_Handle largeIcon = new();
                     using HICON_Handle smallIcon = new();
 
-                    icon.Extract(iconPath, (uint)iconIndex, largeIcon.Ref, smallIcon.Ref, 0);
-                    Get(largeIcon.Value, (c, s, i) => c.CacheIcon(key, s, i));
-                    Get(smallIcon.Value, (c, s, i) => c.CacheIcon(key, s, i));
+                    icon.Extract(iconPath, (uint)iconIndex, ref largeIcon.Handle, ref smallIcon.Handle, 0);
+                    Get(largeIcon, (c, s, i) => c.CacheIcon(key, s, i));
+                    Get(smallIcon, (c, s, i) => c.CacheIcon(key, s, i));
                     image = Get(key, size);
                 }
                 catch (Exception genericException)

--- a/core/native/refresh/src/main/csharp/ViewModels/Preferences/Pages/ProfileViewModel.cs
+++ b/core/native/refresh/src/main/csharp/ViewModels/Preferences/Pages/ProfileViewModel.cs
@@ -2,7 +2,6 @@
 using ch.cyberduck.core.local;
 using ch.cyberduck.core.profiles;
 using ReactiveUI;
-using ReactiveUI.Fody.Helpers;
 using System.Linq;
 using System.Reactive;
 
@@ -10,6 +9,8 @@ namespace Ch.Cyberduck.Core.Refresh.ViewModels.Preferences.Pages
 {
     public class ProfileViewModel : ReactiveObject
     {
+        private bool installed;
+
         public ProfileViewModel(ProfileDescription profile)
         {
             ProfileDescription = profile;
@@ -29,8 +30,11 @@ namespace Ch.Cyberduck.Core.Refresh.ViewModels.Preferences.Pages
 
         public string Description => Profile.getDescription();
 
-        [Reactive]
-        public bool Installed { get; set; }
+        public bool Installed
+        {
+            get => installed;
+            set => this.RaiseAndSetIfChanged(ref installed, value);
+        }
 
         public string Name => Profile.getName();
 

--- a/core/src/main/csharp/Cyberduck.Core.Native.csproj
+++ b/core/src/main/csharp/Cyberduck.Core.Native.csproj
@@ -35,12 +35,9 @@
 
   <ItemGroup>
     <PackageReference Include="ExceptionReporter " />
-    <PackageReference Include="Fody" />
-    <PackageReference Include="InlineIL.Fody" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
     <PackageReference Include="Microsoft.Windows.CsWin32" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/core/src/main/csharp/System/Diagnostics/CodeAnalysis/UnscopedRefAttribute.cs
+++ b/core/src/main/csharp/System/Diagnostics/CodeAnalysis/UnscopedRefAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+public sealed class UnscopedRefAttribute : Attribute
+{
+}

--- a/core/src/main/csharp/Windows/Win32/AdvApi32.cs
+++ b/core/src/main/csharp/Windows/Win32/AdvApi32.cs
@@ -1,16 +1,23 @@
-﻿using Windows.Win32.Security.Credentials;
+﻿#pragma warning disable IDE0001,IDE0002,IDE0005,CS1591,CS1573,CS0465,CS0649,CS8019,CS1570,CS1584,CS1658,CS0436
 
 namespace Windows.Win32
 {
+    using global::System;
+    using global::System.Diagnostics;
+    using global::System.Runtime.CompilerServices;
+    using global::System.Runtime.InteropServices;
+    using winmdroot = global::Windows.Win32;
+
     public partial class CorePInvoke
     {
-        /// <inheritdoc cref="CredRead(Foundation.PCWSTR, uint, uint, CREDENTIALW**)"/>
-        public static unsafe bool CredRead(string TargetName, CRED_TYPE type, CRED_FLAGS flags, out CREDENTIALW credential)
+		/// <inheritdoc cref="CredRead(winmdroot.Foundation.PCWSTR, uint, uint, winmdroot.Security.Credentials.CREDENTIALW**)"/>
+        public static unsafe winmdroot.Security.Credentials.CredHandle CredRead(string TargetName, winmdroot.Security.Credentials.CRED_TYPE type, winmdroot.Security.Credentials.CRED_FLAGS flags)
         {
-            fixed (CREDENTIALW* credentialLocal = &credential)
-            fixed (char* targetNameLocal = TargetName)
+            fixed(char* targetNameLocal = TargetName)
             {
-                return CredRead(targetNameLocal, (uint)type, (uint)flags, (CREDENTIALW**)credentialLocal);
+                winmdroot.Security.Credentials.CREDENTIALW* credential = default;
+                bool __result = CredRead(targetNameLocal, (uint)type, (uint)flags, &credential);
+                return new winmdroot.Security.Credentials.CredHandle(credential);
             }
         }
     }

--- a/core/src/main/csharp/Windows/Win32/CredHandle.cs
+++ b/core/src/main/csharp/Windows/Win32/CredHandle.cs
@@ -1,6 +1,4 @@
-﻿using static InlineIL.FieldRef;
-using static InlineIL.IL;
-using static InlineIL.IL.Emit;
+﻿using System.Diagnostics.CodeAnalysis;
 using static Windows.Win32.CorePInvoke;
 
 namespace Windows.Win32.Security.Credentials
@@ -9,31 +7,13 @@ namespace Windows.Win32.Security.Credentials
     {
         private CREDENTIALW* ptr;
 
-        public ref CREDENTIALW Handle
+        public CredHandle(in CREDENTIALW* pointer)
         {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(CredHandle), nameof(ptr)));
-                Ret(); // return ref *(CREDENTIALW*)&ptr;
-                throw Unreachable();
-            }
+            ptr = pointer;
         }
 
-        public ref CREDENTIALW* Pointer
-        {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(CredHandle), nameof(ptr)));
-                Ret(); // return ref ptr;
-                throw Unreachable();
-            }
-        }
+        [UnscopedRef]
+        public ref CREDENTIALW* Pointer => ref ptr;
 
         public ref CREDENTIALW Value => ref *ptr;
 

--- a/core/src/main/csharp/Windows/Win32/FriendlyOverloadExtensions.cs
+++ b/core/src/main/csharp/Windows/Win32/FriendlyOverloadExtensions.cs
@@ -22,11 +22,13 @@ namespace Windows.Win32
         }
 
         /// <inheritdoc cref="winmdroot.UI.Shell.IExtractIconW.Extract(winmdroot.Foundation.PCWSTR, uint, winmdroot.UI.WindowsAndMessaging.HICON*, winmdroot.UI.WindowsAndMessaging.HICON*, uint)"/>
-		public static unsafe void Extract(this winmdroot.UI.Shell.IExtractIconW @this, string pszFile, uint nIconIndex, in winmdroot.UI.WindowsAndMessaging.HICON phiconLarge, in winmdroot.UI.WindowsAndMessaging.HICON phiconSmall, uint nIconSize)
+		public static unsafe void Extract(this winmdroot.UI.Shell.IExtractIconW @this, string pszFile, uint nIconIndex, ref winmdroot.UI.WindowsAndMessaging.HICON phiconLarge, ref winmdroot.UI.WindowsAndMessaging.HICON phiconSmall, uint nIconSize)
         {
             fixed (char* pszFileLocal = pszFile)
+            fixed (winmdroot.UI.WindowsAndMessaging.HICON* phiconLargeLocal = &phiconLarge)
+            fixed (winmdroot.UI.WindowsAndMessaging.HICON* phiconSmallLocal = &phiconSmall)
             {
-                @this.Extract(pszFileLocal, nIconIndex, (winmdroot.UI.WindowsAndMessaging.HICON*)phiconLarge.Value, (winmdroot.UI.WindowsAndMessaging.HICON*)phiconSmall.Value, nIconSize);
+                @this.Extract(pszFileLocal, nIconIndex, phiconLargeLocal, phiconSmallLocal, nIconSize);
             }
         }
 

--- a/core/src/main/csharp/Windows/Win32/HICON_Handle.cs
+++ b/core/src/main/csharp/Windows/Win32/HICON_Handle.cs
@@ -1,6 +1,4 @@
-﻿using static InlineIL.FieldRef;
-using static InlineIL.IL;
-using static InlineIL.IL.Emit;
+﻿using System.Diagnostics.CodeAnalysis;
 using static Windows.Win32.CorePInvoke;
 
 namespace Windows.Win32.UI.WindowsAndMessaging
@@ -9,39 +7,21 @@ namespace Windows.Win32.UI.WindowsAndMessaging
     {
         private HICON ptr;
 
-        public HICON Ref
+        public HICON_Handle(in HICON handle)
         {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(HICON_Handle), nameof(ptr)));
-                Ret();
-                throw Unreachable();
-            }
+            ptr = handle;
         }
 
-        public ref HICON Value
-        {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(HICON_Handle), nameof(ptr)));
-                Ret(); // return ref *(HICON*)&ptr;
-                throw Unreachable();
-            }
-        }
+        [UnscopedRef]
+        public ref HICON Handle => ref ptr;
 
-        public static implicit operator bool(in HICON_Handle @this) => @this.ptr != null;
+        public static implicit operator bool(in HICON_Handle @this) => !@this.ptr.IsNull;
 
-        public static implicit operator HICON_Handle(in HICON hicon) => new() { ptr = hicon };
+        public static implicit operator nint(in HICON_Handle @this) => @this.ptr;
 
         public void Dispose()
         {
-            if (ptr != null)
+            if (!ptr.IsNull)
             {
                 DestroyIcon(ptr);
                 ptr = default;

--- a/core/src/main/csharp/Windows/Win32/PIDLIST_ABSOLUTEHandle.cs
+++ b/core/src/main/csharp/Windows/Win32/PIDLIST_ABSOLUTEHandle.cs
@@ -1,6 +1,4 @@
-﻿using static InlineIL.FieldRef;
-using static InlineIL.IL;
-using static InlineIL.IL.Emit;
+﻿using System.Diagnostics.CodeAnalysis;
 using static System.Runtime.CompilerServices.Unsafe;
 using static Windows.Win32.CorePInvoke;
 
@@ -10,37 +8,20 @@ namespace Windows.Win32.UI.Shell.Common
     {
         private ITEMIDLIST* ptr;
 
-        public ref ITEMIDLIST Handle
+        public PIDLIST_ABSOLUTEHandle(in ITEMIDLIST* ptr)
         {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(PIDLIST_ABSOLUTEHandle), nameof(ptr)));
-                Ret(); // return ref *(ITEMIDLIST*)&ptr;
-                throw Unreachable();
-            }
+            this.ptr = ptr;
         }
 
-        public ref ITEMIDLIST* Pointer
-        {
-            get
-            {
-                // C# doesn't allow return ref ptr.
-                // IL doesn't have a problem with it.
-                Ldarg_0();
-                Ldflda(Field(typeof(PIDLIST_ABSOLUTEHandle), nameof(ptr)));
-                Ret(); // return ref ptr;
-                throw Unreachable();
-            }
-        }
+        [UnscopedRef]
+        public ref ITEMIDLIST* Pointer => ref ptr;
 
+        [UnscopedRef]
         public ref ITEMIDLIST Value => ref *ptr;
 
         public static implicit operator bool(in PIDLIST_ABSOLUTEHandle @this) => @this.ptr != null;
 
-        public static implicit operator PIDLIST_ABSOLUTEHandle(in ITEMIDLIST pidl) => new() { ptr = (ITEMIDLIST*)AsPointer(ref AsRef(pidl)) };
+        public static implicit operator PIDLIST_ABSOLUTEHandle(in ITEMIDLIST pidl) => new((ITEMIDLIST*)AsPointer(ref AsRef(pidl)));
 
         public void Dispose()
         {

--- a/core/src/main/csharp/Windows/Win32/Shell32.cs
+++ b/core/src/main/csharp/Windows/Win32/Shell32.cs
@@ -1,91 +1,91 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using Windows.Win32.Foundation;
-using Windows.Win32.Storage.FileSystem;
-using Windows.Win32.System.Com;
-using Windows.Win32.UI.Shell;
-using Windows.Win32.UI.Shell.Common;
-using Windows.Win32.UI.WindowsAndMessaging;
-using static System.Runtime.CompilerServices.Unsafe;
+﻿#pragma warning disable IDE0001,IDE0002,IDE0005,CS1591,CS1573,CS0465,CS0649,CS8019,CS1570,CS1584,CS1658,CS0436
 
 namespace Windows.Win32
 {
+    using global::System;
+    using global::System.Diagnostics;
+    using global::System.Runtime.CompilerServices;
+    using global::System.Runtime.InteropServices;
+    using winmdroot = global::Windows.Win32;
+
     public partial class CorePInvoke
     {
         /// <inheritdoc cref="ExtractIconEx(winmdroot.Foundation.PCWSTR, int, winmdroot.UI.WindowsAndMessaging.HICON*, winmdroot.UI.WindowsAndMessaging.HICON*, uint)"/>
-		public static unsafe uint ExtractIconEx(string lpszFile, int nIconIndex, in HICON phiconLarge, in HICON phiconSmall, uint nIcons)
+		public static unsafe uint ExtractIconEx(string lpszFile, int nIconIndex, in winmdroot.UI.WindowsAndMessaging.HICON phiconLarge, in winmdroot.UI.WindowsAndMessaging.HICON phiconSmall, uint nIcons)
         {
             fixed (char* lpszFileLocal = lpszFile)
+            fixed (winmdroot.UI.WindowsAndMessaging.HICON* phiconLargeLocal = &phiconLarge)
+            fixed (winmdroot.UI.WindowsAndMessaging.HICON* phiconSmallLocal = &phiconSmall)
             {
-                uint __result = ExtractIconEx(lpszFileLocal, nIconIndex, (HICON*)phiconLarge.Value, (HICON*)phiconSmall.Value, nIcons);
+                uint __result = ExtractIconEx(lpszFileLocal, nIconIndex, phiconLargeLocal, phiconSmallLocal, nIcons);
                 return __result;
             }
         }
 
         /// <inheritdoc cref="ILCreateFromPath(PCWSTR)"/>
-        public static unsafe ref ITEMIDLIST ILCreateFromPath2(string pszPath)
+        public static unsafe ref winmdroot.UI.Shell.Common.ITEMIDLIST ILCreateFromPath2(string pszPath)
         {
             fixed (char* pszPathLocal = pszPath)
             {
-                ITEMIDLIST* __result = ILCreateFromPath(pszPathLocal);
+                winmdroot.UI.Shell.Common.ITEMIDLIST* __result = ILCreateFromPath(pszPathLocal);
                 return ref *__result;
             }
         }
 
         /// <inheritdoc cref="SHCreateAssociationRegistration(global::System.Guid*, void**)"/>
-        public static unsafe HRESULT SHCreateAssociationRegistration<T>(out T ppv)
+        public static unsafe winmdroot.Foundation.HRESULT SHCreateAssociationRegistration<T>(out T ppv)
         {
             Guid riid = typeof(T).GUID;
             void* ppvLocal;
-            HRESULT __result = SHCreateAssociationRegistration(&riid, &ppvLocal);
+            winmdroot.Foundation.HRESULT __result = SHCreateAssociationRegistration(&riid, &ppvLocal);
             ppv = (T)Marshal.GetObjectForIUnknown((IntPtr)ppvLocal);
             return __result;
         }
 
         /// <inheritdoc cref="SHCreateFileExtractIcon(winmdroot.Foundation.PCWSTR, uint, global::System.Guid*, void**)"/>
-		public static unsafe HRESULT SHCreateFileExtractIcon<T>(string pszFile, uint dwFileAttributes, out T ppv)
+		public static unsafe winmdroot.Foundation.HRESULT SHCreateFileExtractIcon<T>(string pszFile, uint dwFileAttributes, out T ppv)
         {
             Guid riid = typeof(T).GUID;
             void* ppvLocal;
             fixed (char* pszFileLocal = pszFile)
             {
-                HRESULT __result = SHCreateFileExtractIcon(pszFileLocal, dwFileAttributes, &riid, &ppvLocal);
+                winmdroot.Foundation.HRESULT __result = SHCreateFileExtractIcon(pszFileLocal, dwFileAttributes, &riid, &ppvLocal);
                 ppv = (T)Marshal.GetObjectForIUnknown((IntPtr)ppvLocal);
                 return __result;
             }
         }
 
         /// <inheritdoc cref="SHCreateItemFromIDList(winmdroot.UI.Shell.Common.ITEMIDLIST*, global::System.Guid*, void**)"/>
-        public static unsafe HRESULT SHCreateItemFromIDList<T>(in ITEMIDLIST pidl, out T ppv)
+        public static unsafe winmdroot.Foundation.HRESULT SHCreateItemFromIDList<T>(in winmdroot.UI.Shell.Common.ITEMIDLIST pidl, out T ppv)
         {
             Guid riid = typeof(T).GUID;
             void* ppvLocal;
-            fixed (ITEMIDLIST* pidlLocal = &pidl)
+            fixed (winmdroot.UI.Shell.Common.ITEMIDLIST* pidlLocal = &pidl)
             {
-                HRESULT __result = SHCreateItemFromIDList(pidlLocal, &riid, &ppvLocal);
+                winmdroot.Foundation.HRESULT __result = SHCreateItemFromIDList(pidlLocal, &riid, &ppvLocal);
                 ppv = (T)Marshal.GetObjectForIUnknown((IntPtr)ppvLocal);
                 return __result;
             }
         }
 
-        /// <inheritdoc cref="SHGetFileInfo(PCWSTR, FILE_FLAGS_AND_ATTRIBUTES, SHFILEINFOW*, uint, SHGFI_FLAGS)"/>
-        public static unsafe nuint SHGetFileInfo(string pszPath, FILE_FLAGS_AND_ATTRIBUTES dwFileAttributes, in SHFILEINFOW sfi, SHGFI_FLAGS uFlags)
+		/// <inheritdoc cref="SHGetFileInfo(winmdroot.Foundation.PCWSTR, winmdroot.Storage.FileSystem.FILE_FLAGS_AND_ATTRIBUTES, winmdroot.UI.Shell.SHFILEINFOW*, uint, winmdroot.UI.Shell.SHGFI_FLAGS)"/>
+        public static unsafe nuint SHGetFileInfo(string pszPath, winmdroot.Storage.FileSystem.FILE_FLAGS_AND_ATTRIBUTES dwFileAttributes, in winmdroot.UI.Shell.SHFILEINFOW sfi, winmdroot.UI.Shell.SHGFI_FLAGS uFlags)
         {
-            fixed (SHFILEINFOW* psfiLocal = &sfi)
+            fixed (winmdroot.UI.Shell.SHFILEINFOW* psfiLocal = &sfi)
             fixed (char* pszPathLocal = pszPath)
             {
-                return SHGetFileInfo(pszPathLocal, dwFileAttributes, psfiLocal, (uint)SizeOf<SHFILEINFOW>(), uFlags);
+                return SHGetFileInfo(pszPathLocal, dwFileAttributes, psfiLocal, (uint)Marshal.SizeOf<winmdroot.UI.Shell.SHFILEINFOW>(), uFlags);
             }
         }
 
-        /// <inheritdoc cref="SHParseDisplayName(string, IBindCtx, out ITEMIDLIST*, uint, uint*)"/>
-        public static unsafe HRESULT SHParseDisplayName(string pszName, IBindCtx pbc, out ITEMIDLIST ppidl, uint sfgaoIn, out uint psfgaOut)
+        /// <inheritdoc cref="SHParseDisplayName(string, winmdroot.System.Com.IBindCtx, out winmdroot.UI.Shell.Common.ITEMIDLIST*, uint, uint*)"/>
+        public static unsafe winmdroot.Foundation.HRESULT SHParseDisplayName(string pszName, winmdroot.System.Com.IBindCtx pbc, out winmdroot.UI.Shell.Common.ITEMIDLIST ppidl, uint sfgaoIn, out uint psfgaOut)
         {
-            fixed (ITEMIDLIST* ppidlLocal = &ppidl)
+            fixed (winmdroot.UI.Shell.Common.ITEMIDLIST* ppidlLocal = &ppidl)
             fixed (uint* psfgaOutLocal = &psfgaOut)
             fixed (char* pszNameLocal = pszName)
             {
-                return SHParseDisplayName(pszNameLocal, pbc, (ITEMIDLIST**)ppidlLocal, sfgaoIn, psfgaOutLocal);
+                return SHParseDisplayName(pszNameLocal, pbc, (winmdroot.UI.Shell.Common.ITEMIDLIST**)ppidlLocal, sfgaoIn, psfgaOutLocal);
             }
         }
     }

--- a/core/src/main/csharp/Windows/Win32/User32.cs
+++ b/core/src/main/csharp/Windows/Win32/User32.cs
@@ -1,15 +1,21 @@
-﻿using Windows.Win32.Foundation;
+﻿#pragma warning disable IDE0001,IDE0002,IDE0005,CS1591,CS1573,CS0465,CS0649,CS8019,CS1570,CS1584,CS1658,CS0436
 
 namespace Windows.Win32
 {
+    using global::System;
+    using global::System.Diagnostics;
+    using global::System.Runtime.CompilerServices;
+    using global::System.Runtime.InteropServices;
+    using winmdroot = global::Windows.Win32;
+
     public partial class CorePInvoke
     {
-        /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
-        public static unsafe LRESULT SendMessage(HWND hWnd, uint Msg, WPARAM wParam, in string lParam)
-            => SendMessage(hWnd, Msg, wParam, (PCWSTR)lParam);
+        /// <inheritdoc cref="SendMessage(winmdroot.Foundation.HWND, uint, winmdroot.Foundation.WPARAM, winmdroot.Foundation.LPARAM)"/>
+        public static unsafe winmdroot.Foundation.LRESULT SendMessage(winmdroot.Foundation.HWND hWnd, uint Msg, winmdroot.Foundation.WPARAM wParam, in string lParam)
+            => SendMessage(hWnd, Msg, wParam, (winmdroot.Foundation.PCWSTR)lParam);
 
-        /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
-        public static unsafe LRESULT SendMessage(HWND hWnd, uint Msg, WPARAM wParam, PCWSTR lParam)
+        /// <inheritdoc cref="SendMessage(winmdroot.Foundation.HWND, uint, winmdroot.Foundation.WPARAM, winmdroot.Foundation.LPARAM)"/>
+        public static unsafe winmdroot.Foundation.LRESULT SendMessage(winmdroot.Foundation.HWND hWnd, uint Msg, winmdroot.Foundation.WPARAM wParam, winmdroot.Foundation.PCWSTR lParam)
             => SendMessage(hWnd, Msg, wParam, (nint)lParam.Value);
     }
 }

--- a/core/src/main/csharp/ch/cyberduck/core/credentialmanager/WinCredentialManager.cs
+++ b/core/src/main/csharp/ch/cyberduck/core/credentialmanager/WinCredentialManager.cs
@@ -56,10 +56,10 @@ namespace Ch.Cyberduck.Core.CredentialManager
         /// </summary>
         /// <param name="target">Name of the application/Url where the credential is used for</param>
         /// <returns>empty credentials if target not found, else stored credentials</returns>
-        public static unsafe WindowsCredentialManagerCredential GetCredentials(string target)
+        public unsafe static WindowsCredentialManagerCredential GetCredentials(string target)
         {
-            using CredHandle handle = new();
-            if (!CredRead(target, CRED_TYPE_GENERIC, 0, out handle.Handle))
+            using CredHandle handle = CredRead(target, CRED_TYPE_GENERIC, 0);
+            if (!handle)
             {
                 if (log.isDebugEnabled())
                 {
@@ -69,7 +69,7 @@ namespace Ch.Cyberduck.Core.CredentialManager
                 return default;
             }
 
-            ref CREDENTIALW cred = ref handle.Value;
+            ref readonly CREDENTIALW cred = ref handle.Value;
             var type = cred.Type;
             var flags = cred.Flags;
             var persist = cred.Persist;

--- a/core/src/main/csharp/ch/cyberduck/core/local/ExplorerRevealService.cs
+++ b/core/src/main/csharp/ch/cyberduck/core/local/ExplorerRevealService.cs
@@ -17,7 +17,6 @@
 // 
 
 using ch.cyberduck.core.local;
-using Windows.Win32.UI.Shell;
 using Windows.Win32.UI.Shell.Common;
 using static Windows.Win32.CorePInvoke;
 

--- a/core/src/test/csharp/Cyberduck.Core.Test.csproj
+++ b/core/src/test/csharp/Cyberduck.Core.Test.csproj
@@ -19,10 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit.Console" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <Target Name="Test">

--- a/windows/src/main/appx/Cyberduck.Package.proj
+++ b/windows/src/main/appx/Cyberduck.Package.proj
@@ -142,9 +142,6 @@
     <LayoutFile Include="$(OutputPath)\IKVM.OpenJDK.Jdbc.dll">
       <PackagePath>$(PackageLayout)\IKVM.OpenJDK.Jdbc.dll</PackagePath>
     </LayoutFile>
-    <LayoutFile Include="$(OutputPath)\Interop.Bonjour.dll">
-      <PackagePath>$(PackageLayout)\Interop.Bonjour.dll</PackagePath>
-    </LayoutFile>
     <LayoutFile Include="$(OutputPath)\ObjectListView.dll">
       <PackagePath>$(PackageLayout)\ObjectListView.dll</PackagePath>
     </LayoutFile>
@@ -189,9 +186,6 @@
     </LayoutFile>
     <LayoutFile Include="$(OutputPath)\ReactiveUI.dll">
       <PackagePath>$(PackageLayout)\ReactiveUI.dll</PackagePath>
-    </LayoutFile>
-    <LayoutFile Include="$(OutputPath)\ReactiveUI.Fody.Helpers.dll">
-      <PackagePath>$(PackageLayout)\ReactiveUI.Fody.Helpers.dll</PackagePath>
     </LayoutFile>
     <LayoutFile Include="$(OutputPath)\ReactiveUI.Wpf.dll">
       <PackagePath>$(PackageLayout)\ReactiveUI.Wpf.dll</PackagePath>

--- a/windows/src/main/csharp/Cyberduck.csproj
+++ b/windows/src/main/csharp/Cyberduck.csproj
@@ -61,22 +61,8 @@
     <PackageReference Include="Microsoft.Windows.CsWin32" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" />
     <PackageReference Include="ObjectListView.Official" />
-    <PackageReference Include="ReactiveUI.Fody" />
     <PackageReference Include="ReactiveUI.WPF" />
     <PackageReference Include="StructureMap" />
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <COMReference Include="Bonjour">
-      <Guid>{18FBED6D-F2B7-4EC8-A4A4-46282E635308}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-    </COMReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/src/main/wix/Bundle/Cyberduck.wxs
+++ b/windows/src/main/wix/Bundle/Cyberduck.wxs
@@ -188,9 +188,6 @@
       <Component Id="ikvm.misc" Guid="29564F63-CA76-4944-9022-D705E038DF24">
         <File Source="$(var.cyberduck.TargetDir)/IKVM.OpenJDK.Misc.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Id="Interop.Bonjour">
-        <File Source="$(var.cyberduck.TargetDir)/Interop.Bonjour.dll" KeyPath="yes" Checksum="yes"/>
-      </Component>
       <Component Id="objectlistview">
         <File Source="$(var.cyberduck.TargetDir)/ObjectListView.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
@@ -248,10 +245,6 @@
       <!-- System.Reactive -->
       <Component Id="System.Reactive">
         <File Source="$(var.cyberduck.TargetDir)/System.Reactive.dll" KeyPath="yes" Checksum="yes" />
-      </Component>
-      <!-- ReactiveUI.Fody-->
-      <Component Id="ReactiveUI.Fody.Helpers">
-        <File Source="$(var.cyberduck.TargetDir)/ReactiveUI.Fody.Helpers.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- ReactiveUI.WPF-->
       <Component Id="ReactiveUI.Wpf">

--- a/windows/src/test/csharp/Cyberduck.Test.csproj
+++ b/windows/src/test/csharp/Cyberduck.Test.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit.Console" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
   <Target Name="Test">


### PR DESCRIPTION
Everything can be represented in C#, thus don't use Fody.

Don't need magic-property generation.

Changes:
- Embed Bonjour COM interop types
- Remove InlineIL with simpler constructs (new UnscopedRef-feature in CSC/Roslyn)
- Remove automatic reactive property generation
- Format some CsWin32-generated files