### PR TITLE
From https://developer.apple.com/documentation/appkit/nsapplicationde…

### DIFF
--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
@@ -901,7 +901,7 @@ public class MainController extends BundleController implements NSApplication.De
      * (applicationWillFinishLaunching is sent before applicationOpenFile.)
      */
     @Override
-    public void applicationDidFinishLaunching(NSNotification notification) {
+    public void applicationWillFinishLaunching(NSNotification notification) {
         // Opt-in of automatic window tabbing
         NSWindow.setAllowsAutomaticWindowTabbing(true);
         // Load main menu


### PR DESCRIPTION
…legate/1428612-application?language=objc : If the user started up the application by double-clicking a file, the delegate receives the application:openFile: message before receiving applicationDidFinishLaunching:. (applicationWillFinishLaunching: is sent before application:openFile:.)