### PR TITLE
Force restore of net472 assemblies in $(TargetDir), otherwise netstandard2.0 is installed

### DIFF
--- a/windows/src/main/package/package.wapproj
+++ b/windows/src/main/package/package.wapproj
@@ -22,7 +22,7 @@
         <ProjectGuid>55cdd736-9a8a-4091-ac99-60e2f9c73269</ProjectGuid>
         <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
-        <NoWarn>$(NoWarn);NU1702</NoWarn>
+        <AssetTargetFallback>net472;$(AssetTargetFallback)</AssetTargetFallback>
         <EntryPointProjectUniqueName>..\csharp\Cyberduck.csproj</EntryPointProjectUniqueName>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
This results in subsequent launches of Cyberduck.exe to fail

Only a dev-time annoyance, no impact on built artifacts