### PR TITLE
Allow empty passwords for SFTP interactive challenge

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPChallengeResponseAuthentication.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPChallengeResponseAuthentication.java
@@ -150,6 +150,7 @@ public class SFTPChallengeResponseAuthentication implements AuthenticationProvid
                                             .password(true)
                                             .user(false)
                                             .keychain(false)
+                                            .anonymous(true)
                             );
                         }
                         catch(LoginCanceledException e) {


### PR DESCRIPTION
The SFTP servers I use all require an MFA challenge. This MFA solution requires me to either enter a one-time passcode or send an empty response back, in which case I get a notification on my MFA device to confirm my login request. However, the SFTP Challenge Prompt currently does not allow empty inputs.

I think allowing empty responses to the SFTP challenge covers my use case without (hopefully) breaking functionality for existing users. I tested the code in the PR on my own machine and it works as expected, an additional "Skip" button is added to the prompt window and clicking that allows me to receive my notification.

Please let me know if there are any issues, I'll be glad to make any additional changes/improvements.

Thanks!