### PR TITLE
Set timestamp in transfer status depending on support in write feature

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/transfer/upload/AbstractUploadFilter.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/upload/AbstractUploadFilter.java
@@ -217,8 +217,7 @@ public abstract class AbstractUploadFilter implements TransferPathFilter {
             }
         }
         if(options.timestamp) {
-            final Timestamp feature = session.getFeature(Timestamp.class);
-            if(feature != null) {
+            if(session.getFeature(Write.class).timestamp()) {
                 if(1L != local.attributes().getModificationDate()) {
                     status.setModified(local.attributes().getModificationDate());
                 }

--- a/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxUploadFeatureTest.java
+++ b/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxUploadFeatureTest.java
@@ -55,6 +55,7 @@ public class DropboxUploadFeatureTest extends AbstractDropboxTest {
         final byte[] content = RandomUtils.nextBytes(length);
         IOUtils.write(content, local.getOutputStream(false));
         final TransferStatus status = new TransferStatus();
+        status.setModified(1700638960509L);
         status.setLength(content.length);
         status.setMime("text/plain");
         final BytecountStreamListener count = new BytecountStreamListener();
@@ -64,6 +65,7 @@ public class DropboxUploadFeatureTest extends AbstractDropboxTest {
         assertTrue(status.isComplete());
         assertTrue(new DropboxFindFeature(session).find(test));
         final PathAttributes attributes = new DropboxAttributesFinderFeature(session).find(test);
+        assertEquals(1700638960000L, attributes.getModificationDate());
         assertEquals(content.length, attributes.getSize());
         assertEquals(((FileMetadata) metadata).getContentHash(), attributes.getChecksum().hash);
         new DropboxDeleteFeature(session).delete(Collections.singletonList(test), new DisabledLoginCallback(), new Delete.DisabledCallback());

--- a/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxWriteFeatureTest.java
+++ b/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxWriteFeatureTest.java
@@ -54,6 +54,7 @@ public class DropboxWriteFeatureTest extends AbstractDropboxTest {
     public void testReadWrite() throws Exception {
         final DropboxWriteFeature write = new DropboxWriteFeature(session);
         final TransferStatus status = new TransferStatus();
+        status.setModified(1700638960509L);
         final byte[] content = RandomUtils.nextBytes(66800);
         status.setLength(content.length);
         final Path test = new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file));
@@ -65,6 +66,7 @@ public class DropboxWriteFeatureTest extends AbstractDropboxTest {
         assertTrue(new DropboxFindFeature(session).find(test));
         final PathAttributes attributes = new DropboxListService(session).list(test.getParent(), new DisabledListProgressListener()).get(test).attributes();
         assertEquals(status.getResponse(), attributes);
+        assertEquals(1700638960000L, attributes.getModificationDate());
         assertEquals(content.length, attributes.getSize());
         assertEquals(content.length, write.append(test, status.withRemote(attributes)).size, 0L);
         {


### PR DESCRIPTION
Fix #15381.