### PR TITLE
Add codespell: config, workflow (to alert when new typos added) and get typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj
+skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj,*.resx
 check-hidden = true
 ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b|.*codespell-ignore.*
 ignore-words-list = doubleclick,ser,fro,ist,fle

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj,*.resx
+skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj,*.resx,*.plist
 check-hidden = true
-ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b|.*codespell-ignore.*
+ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b|.*codespell-ignore.*|wasn&#x27;t
 ignore-words-list = doubleclick,ser,fro,ist,fle

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
 skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj
 check-hidden = true
-ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure)\b
-ignore-words-list = doubleclick,ser,fro,ist
+ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b
+ignore-words-list = doubleclick,ser,fro,ist,fle

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
 skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj
 check-hidden = true
-ignore-regex = \b(absolute[XY]|CLASSs|characterClasses)\b
+ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure)\b
 ignore-words-list = doubleclick,ser,fro,ist

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj,*.resx,*.plist
+skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj,*.resx,*.plist,swagger
 check-hidden = true
 ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b|.*codespell-ignore.*|wasn&#x27;t
 ignore-words-list = doubleclick,ser,fro,ist,fle

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
 skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj
 check-hidden = true
-ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b
+ignore-regex = \b(absolute[XY]|CLASSs|characterClasses|connection\.unsecure|perm=fle)\b|.*codespell-ignore.*
 ignore-words-list = doubleclick,ser,fro,ist,fle

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,*.pdf,*.svg,.codespellrc,*.cs,*.cyberduckprofile,*.ini,*.xib,*.rtf,*.lproj,*.types,TIMEZONES,*.sdef,*.csproj
+check-hidden = true
+ignore-regex = \b(absolute[XY]|CLASSs|characterClasses)\b
+ignore-words-list = doubleclick,ser,fro,ist

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -702,7 +702,7 @@ https://cyberduck.io/
 - [Bugfix] Do not save vault passphrase by default (Cryptomator)
 - [Bugfix] Fix failures when attempting to read attributes of incomplete multipart upload (S3)
 - [Bugfix] Reloading directory after enabling "Auto detect" in preferences does not ask to unlock vault (Cryptomator) (#10214)
-- [Bugfix] Transfer labled incomplete when segment required multiple attempts to finish (S3, OpenStack Swift, Backblaze B2) (#9552)
+- [Bugfix] Transfer labeled incomplete when segment required multiple attempts to finish (S3, OpenStack Swift, Backblaze B2) (#9552)
 
 6.3.5
 - [Bugfix] Crash on launch in update checker (Windows)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -8,7 +8,7 @@ https://cyberduck.io/
 - [Bugfix] Crash when opening application (Windows) (#15535)
 
 8.7.2
-- [Bugfix] Missing digest header when commiting large file upload (Box) (#14564)
+- [Bugfix] Missing digest header when committing large file upload (Box) (#14564)
 - [Bugfix] Modification date not set in upload (Dropbox) (#15381)
 - [Bugfix] Setting modification date truncates file (SMB) (#15495)
 
@@ -362,7 +362,7 @@ https://cyberduck.io/
 
 7.8.1
 - [Feature] Provide armhf/aarch64 RPM and DEB packages (CLI, Rasperry Pi, Linux) (#10447)
-- [Bugfix] Missing folers in directory listing (OneDrive, SharePoint)
+- [Bugfix] Missing folders in directory listing (OneDrive, SharePoint)
 - [Bugfix] Interoperability with Tencent Cloud Object Storage (S3)
 - [Bugfix] No file size displayed for files (Google Drive)
 
@@ -1535,7 +1535,7 @@ https://cyberduck.io/
 - [Feature] Copy directory listing to clipboard (#2372)
 - [Feature] Support for thirdparty terminal applications (#2987)
 - [Feature] Change SSH options for open in Terminal.app (#4232)
-- [Feature] Unsecure connection warning when password is transmitted in plaintext
+- [Feature] Insecure connection warning when password is transmitted in plaintext
 - [Feature] Alert to change connection to TLS if server supports AUTH TLS (FTP)
 - [Feature] Edit metadata for multiple files (S3, Google Cloud Storage)
 - [Feature] Menu items to copy HTTP, CDN, signed & authenticated URLs to clipboard (#4207)
@@ -1917,7 +1917,7 @@ https://cyberduck.io/
 - [Bugfix] Cannot login with colon in username (#309)
 - [Bugfix] Cannot delete directory from server (#256)
 - [Bugfix] Permission errors when downloading files from read-only directories (#264)
-- [Bugfix] Change download keyboad shortcut (#277)
+- [Bugfix] Change download keyboard shortcut (#277)
 - [Bugfix] Certain operations trigger change of character encoding to default
 - [Bugfix] Character encoding issues (#238, #333, #361, #390)
 - [Bugfix] Improved compatibility with certain FTP servers

--- a/binding/src/main/java/ch/cyberduck/binding/AbstractTableDelegate.java
+++ b/binding/src/main/java/ch/cyberduck/binding/AbstractTableDelegate.java
@@ -55,7 +55,7 @@ public abstract class AbstractTableDelegate<E, Column> extends ProxyController i
     }
 
     /**
-     * @return By default no column is editable. To be overriden in subclasses
+     * @return By default no column is editable. To be overridden in subclasses
      */
     public boolean isColumnRowEditable(final NSTableColumn column, final NSInteger row) {
         return false;

--- a/binding/src/main/java/ch/cyberduck/binding/BundleController.java
+++ b/binding/src/main/java/ch/cyberduck/binding/BundleController.java
@@ -135,7 +135,7 @@ public abstract class BundleController extends ProxyController {
     protected boolean awaked;
 
     /**
-     * Called by the runtime after the NIB file has been loaded sucessfully
+     * Called by the runtime after the NIB file has been loaded successfully
      */
     public void awakeFromNib() {
         log.debug("awakeFromNib");

--- a/binding/src/main/java/ch/cyberduck/binding/application/NSApplication.java
+++ b/binding/src/main/java/ch/cyberduck/binding/application/NSApplication.java
@@ -466,7 +466,7 @@ public abstract class NSApplication extends NSObject {
      * <i>native declaration : :149</i><br>
      * Conversion Error : /**<br> * *  Present a sheet on the given window.  When the modal session is ended,<br> * *
      * the didEndSelector will be invoked in the modalDelegate.  The didEndSelector<br> * * should have the following
-     * signature, and will be invoked when the modal session ends.<br> * * This method should dimiss the sheet using
+     * signature, and will be invoked when the modal session ends.<br> * * This method should dismiss the sheet using
      * orderOut:<br> * * - (void)sheetDidEnd:(NSWindow *)sheet returnCode:(NSInteger)returnCode contextInfo:(void
      * *)contextInfo;<br> * *<br> * Original signature : <code>void beginSheet(NSWindow*, NSWindow*, id, null,
      * void*)</code><br> * /<br> - (void)beginSheet:(NSWindow*)sheet modalForWindow:(NSWindow*)docWindow

--- a/binding/src/main/java/ch/cyberduck/binding/application/NSOutlineView.java
+++ b/binding/src/main/java/ch/cyberduck/binding/application/NSOutlineView.java
@@ -229,7 +229,7 @@ public abstract class NSOutlineView extends NSTableView {
 
     /**
      * This method returns YES to indicate that auto expanded items should return to their original collapsed state.
-     * Override this method to provide custom behavior.  'deposited' tells wether or not the drop terminated due to a
+     * Override this method to provide custom behavior.  'deposited' tells whether or not the drop terminated due to a
      * successful drop (as indicated by the return value from acceptDrop:).  Note that exiting the view will be treated
      * the same as a failed drop.<br> Original signature : <code>BOOL shouldCollapseAutoExpandedItemsForDeposited(BOOL)</code><br>
      * <i>native declaration : :183</i>

--- a/binding/src/main/java/ch/cyberduck/binding/application/NSTableColumn.java
+++ b/binding/src/main/java/ch/cyberduck/binding/application/NSTableColumn.java
@@ -195,7 +195,7 @@ public abstract class NSTableColumn extends NSObject {
     public abstract com.sun.jna.Pointer sortDescriptorPrototype();
 
     /**
-     * The resizing mask controls the resizability of a table column.  Compatability Note: This method replaces setResizable.<br>
+     * The resizing mask controls the resizability of a table column.  Compatibility Note: This method replaces setResizable.<br>
      * Original signature : <code>void setResizingMask(NSUInteger)</code><br>
      * <i>native declaration : :78</i>
      */

--- a/binding/src/main/java/ch/cyberduck/binding/application/NSTableView.java
+++ b/binding/src/main/java/ch/cyberduck/binding/application/NSTableView.java
@@ -160,7 +160,7 @@ public abstract class NSTableView extends NSControl {
     public abstract boolean allowsColumnReordering();
 
     /**
-     * Controls whether the user can attemp to resize columns by dragging between headers. If flag is YES the user can
+     * Controls whether the user can attempt to resize columns by dragging between headers. If flag is YES the user can
      * resize columns; if flag is NO the user can't. The default is YES. Columns can only be resized if a column allows
      * user resizing.  See NSTableColumn setResizingMask: for more details.  You can always change columns
      * programmatically regardless of this setting.<br> Original signature : <code>void
@@ -466,7 +466,7 @@ public abstract class NSTableView extends NSControl {
      * <i>native declaration : :212</i><br>
      * Conversion Error : /**<br>
      *  * This method computes and returns an image to use for dragging.  Override this to return a custom image.  'dragRows' represents the rows participating in the drag.  'tableColumns' represent the columns that should be in the output image.  Note that drawing may be clipped to the visible rows, and columns.  'dragEvent' is a reference to the mouse down event that began the drag.  'dragImageOffset' is an in/out parameter.  This method will be called with dragImageOffset set to NSZeroPoint, but it can be modified to re-position the returned image.  A dragImageOffset of NSZeroPoint will cause the image to be centered under the mouse.<br>
-     *  * Compatability Note: This method replaces dragImageForRows:event:dragImageOffset:.  If present, this is used instead of the deprecated method.<br>
+     *  * Compatibility Note: This method replaces dragImageForRows:event:dragImageOffset:.  If present, this is used instead of the deprecated method.<br>
      *  * Original signature : <code>NSImage* dragImageForRowsWithIndexes(NSIndexSet*, NSArray*, NSEvent*, null)</code><br>
      *  * /<br>
      * - (NSImage*)dragImageForRowsWithIndexes:(NSIndexSet*)dragRows tableColumns:(NSArray*)tableColumns event:(NSEvent*)dragEvent offset:(null)dragImageOffset; (Argument dragImageOffset cannot be converted)
@@ -541,7 +541,7 @@ public abstract class NSTableView extends NSControl {
 
     /**
      * Sets the column selection using the indexes.  Selection is set/extended based on the extend flag. <br>
-     * Compatability Note: This method replaces selectColumn:byExtendingSelection:<br> If a subclasser implements only
+     * Compatibility Note: This method replaces selectColumn:byExtendingSelection:<br> If a subclasser implements only
      * the deprecated single-index method (selectColumn:byExtendingSelection:), the single-index method will be invoked
      * for each index.  If a subclasser implements the multi-index method (selectColumnIndexes:byExtendingSelection:),
      * the deprecated single-index version method will not be used.  This allows subclassers already overriding the
@@ -555,7 +555,7 @@ public abstract class NSTableView extends NSControl {
     /**
      * Sets the row selection using 'indexes'. Selection is set/extended based on the extend flag. On 10.5 and greater,
      * selectRowIndexes:byExtendingSelection: will allow you to progrmatically select more than one index, regardless of
-     * the allowsMultipleSelection and allowsEmptySelection options set on the table.<br> Compatability Note: This
+     * the allowsMultipleSelection and allowsEmptySelection options set on the table.<br> Compatibility Note: This
      * method replaces selectRow:byExtendingSelection:<br> If a subclasser implements only the deprecated single-index
      * method (selectRow:byExtendingSelection:), the single-index method will be invoked for each index.  If a
      * subclasser implements the multi-index method (selectRowIndexes:byExtendingSelection:), the deprecated
@@ -782,7 +782,7 @@ public abstract class NSTableView extends NSControl {
      * Conversion Error : NSRect
      */
     /**
-     * Deprecated in Mac OS 10.3.  Calls setGridStyleMask:, setting grid style to either None, or vertical and horizonal
+     * Deprecated in Mac OS 10.3.  Calls setGridStyleMask:, setting grid style to either None, or vertical and horizontal
      * solid grid lines as appropriate.<br> Original signature : <code>void setDrawsGrid(BOOL)</code><br>
      * <i>from NSDeprecated native declaration : :506</i>
      */

--- a/binding/src/main/java/ch/cyberduck/binding/foundation/FoundationKitFunctions.java
+++ b/binding/src/main/java/ch/cyberduck/binding/foundation/FoundationKitFunctions.java
@@ -122,7 +122,7 @@ public interface FoundationKitFunctions extends Library {
         int NSUserDomainMask = 1;
         /// local to the current machine --- place to install items available to everyone on this machine (/Library)
         int NSLocalDomainMask = 2;
-        /// publically available location in the local area network --- place to install items available on the network (/Network)
+        /// publicly available location in the local area network --- place to install items available on the network (/Network)
         int NSNetworkDomainMask = 4;
         /// provided by Apple, unmodifiable (/System)
         int NSSystemDomainMask = 8;

--- a/binding/src/main/java/ch/cyberduck/binding/foundation/NSFileManager.java
+++ b/binding/src/main/java/ch/cyberduck/binding/foundation/NSFileManager.java
@@ -172,7 +172,7 @@ public abstract class NSFileManager extends NSObject {
     public abstract NSArray contentsOfDirectoryAtPath_error(String path, ObjCObjectByReference error);
 
     /**
-     * subpathsOfDirectoryAtPath:error: returns an NSArray of Strings represeting the filenames of the items in the
+     * subpathsOfDirectoryAtPath:error: returns an NSArray of Strings representing the filenames of the items in the
      * specified directory and all its subdirectories recursively. If this method returns 'nil', an NSError will be
      * returned by reference in the 'error' parameter. If the directory contains no items, this method will return the
      * empty array.<br> This method replaces subpathsAtPath:<br> Original signature :

--- a/binding/src/main/java/ch/cyberduck/binding/foundation/NSString.java
+++ b/binding/src/main/java/ch/cyberduck/binding/foundation/NSString.java
@@ -510,7 +510,7 @@ public abstract class NSString extends NSObject implements NSCopying {
 
     /**
      * Original signature : <code>BOOL getCString(char*, NSUInteger, NSStringEncoding)</code><br>
-     * NO return if conversion not possible due to encoding errors or too small of a buffer. The buffer should include room for maxBufferCount bytes; this number should accomodate the expected size of the return value plus the NULL termination character, which this method adds. (So note that the maxLength passed to this method is one more than the one you would have passed to the deprecated getCString:maxLength:.)<br>
+     * NO return if conversion not possible due to encoding errors or too small of a buffer. The buffer should include room for maxBufferCount bytes; this number should accommodate the expected size of the return value plus the NULL termination character, which this method adds. (So note that the maxLength passed to this method is one more than the one you would have passed to the deprecated getCString:maxLength:.)<br>
      * <i>from NSStringExtensionMethods native declaration : :192</i>
      */
     public abstract boolean getCString_maxLength_encoding(java.nio.ByteBuffer buffer, NSUInteger maxBufferCount, NSUInteger encoding);

--- a/box/src/main/java/ch/cyberduck/core/box/BoxLargeUploadService.java
+++ b/box/src/main/java/ch/cyberduck/core/box/BoxLargeUploadService.java
@@ -104,10 +104,10 @@ public class BoxLargeUploadService extends HttpUploadFeature<File, MessageDigest
                             .size(f.status.getLength()).offset(f.status.getOffset()).partId(f.part.getId())).collect(Collectors.toList()));
             final Optional<File> optional = files.getEntries().stream().findFirst();
             if(optional.isPresent()) {
-                final File commited = optional.get();
+                final File committed = optional.get();
                 // Mark parent status as complete
-                status.withResponse(new BoxAttributesFinderFeature(session, fileid).toAttributes(commited)).setComplete();
-                return commited;
+                status.withResponse(new BoxAttributesFinderFeature(session, fileid).toAttributes(committed)).setComplete();
+                return committed;
             }
             throw new NotfoundException(file.getAbsolute());
         }

--- a/brick/src/main/java/ch/cyberduck/core/brick/BrickUnauthorizedRetryStrategy.java
+++ b/brick/src/main/java/ch/cyberduck/core/brick/BrickUnauthorizedRetryStrategy.java
@@ -70,7 +70,7 @@ public class BrickUnauthorizedRetryStrategy extends DisabledServiceUnavailableRe
                     }
                     // Pairing token no longer valid
                     if(!semaphore.tryAcquire()) {
-                        log.warn(String.format("Skip pairing because semaphore cannot be aquired for %s", session));
+                        log.warn(String.format("Skip pairing because semaphore cannot be acquired for %s", session));
                         return false;
                     }
                     try {

--- a/brick/src/main/resources/api.json
+++ b/brick/src/main/resources/api.json
@@ -10469,15 +10469,15 @@
                     {
                         "name": "recursive",
                         "in": "query",
-                        "description": "If true, will recursively delete folers.  Otherwise, will error on non-empty folders.",
+                        "description": "If true, will recursively delete folders.  Otherwise, will error on non-empty folders.",
                         "required": false,
                         "style": "form",
                         "explode": true,
                         "schema": {
                             "type": "boolean",
-                            "x-ms-summary": "If true, will recursively delete folers.  Otherwise, will error on non-empty folders."
+                            "x-ms-summary": "If true, will recursively delete folders.  Otherwise, will error on non-empty folders."
                         },
-                        "x-ms-summary": "If true, will recursively delete folers.  Otherwise, will error on non-empty folders."
+                        "x-ms-summary": "If true, will recursively delete folders.  Otherwise, will error on non-empty folders."
                     }
                 ],
                 "responses": {
@@ -23721,7 +23721,7 @@
                     },
                     "allowed_countries": {
                         "type": "string",
-                        "description": "Comma seperated list of allowed Country codes",
+                        "description": "Comma separated list of allowed Country codes",
                         "example": "US,DE"
                     },
                     "allowed_ips": {
@@ -23824,7 +23824,7 @@
                     },
                     "disallowed_countries": {
                         "type": "string",
-                        "description": "Comma seperated list of disallowed Country codes",
+                        "description": "Comma separated list of disallowed Country codes",
                         "example": "US,DE"
                     },
                     "disable_notifications": {
@@ -26457,7 +26457,7 @@
                     },
                     "query_user_id": {
                         "type": "string",
-                        "description": "Return results that are actions performed by the user indiciated by this User ID",
+                        "description": "Return results that are actions performed by the user indicated by this User ID",
                         "example": "1"
                     },
                     "query_file_id": {
@@ -26507,7 +26507,7 @@
                     },
                     "query_target_id": {
                         "type": "string",
-                        "description": "If searching for Histories about specific objects (such as Users, or API Keys), this paremeter restricts results to objects that match this ID.",
+                        "description": "If searching for Histories about specific objects (such as Users, or API Keys), this parameter restricts results to objects that match this ID.",
                         "example": "1"
                     },
                     "query_target_name": {
@@ -26517,7 +26517,7 @@
                     },
                     "query_target_permission": {
                         "type": "string",
-                        "description": "If searching for Histories about Permisisons, this parameter restricts results to permissions of this level.",
+                        "description": "If searching for Histories about Permissions, this parameter restricts results to permissions of this level.",
                         "example": "full"
                     },
                     "query_target_user_id": {
@@ -26624,7 +26624,7 @@
                     },
                     "interface": {
                         "type": "string",
-                        "description": "Inteface through which the action was taken. Valid values: `web`, `ftp`, `robot`, `jsapi`, `webdesktopapi`, `sftp`, `dav`, `desktop`, `restapi`, `scim`, `office`",
+                        "description": "Interface through which the action was taken. Valid values: `web`, `ftp`, `robot`, `jsapi`, `webdesktopapi`, `sftp`, `dav`, `desktop`, `restapi`, `scim`, `office`",
                         "example": "ftp"
                     },
                     "target_id": {
@@ -28215,8 +28215,8 @@
                     },
                     "allowed_countries": {
                         "type": "string",
-                        "description": "Comma seperated list of allowed Country codes",
-                        "x-ms-summary": "Comma seperated list of allowed Country codes"
+                        "description": "Comma separated list of allowed Country codes",
+                        "x-ms-summary": "Comma separated list of allowed Country codes"
                     },
                     "allowed_ips": {
                         "type": "string",
@@ -28225,8 +28225,8 @@
                     },
                     "disallowed_countries": {
                         "type": "string",
-                        "description": "Comma seperated list of disallowed Country codes",
-                        "x-ms-summary": "Comma seperated list of disallowed Country codes"
+                        "description": "Comma separated list of disallowed Country codes",
+                        "x-ms-summary": "Comma separated list of disallowed Country codes"
                     },
                     "days_to_retain_backups": {
                         "type": "integer",
@@ -31025,9 +31025,9 @@
                     },
                     "query_user_id": {
                         "type": "string",
-                        "description": "Return results that are actions performed by the user indiciated by this User ID",
+                        "description": "Return results that are actions performed by the user indicated by this User ID",
                         "example": "1",
-                        "x-ms-summary": "Return results that are actions performed by the user indiciated by this User ID"
+                        "x-ms-summary": "Return results that are actions performed by the user indicated by this User ID"
                     },
                     "query_file_id": {
                         "type": "string",
@@ -31085,9 +31085,9 @@
                     },
                     "query_target_id": {
                         "type": "string",
-                        "description": "If searching for Histories about specific objects (such as Users, or API Keys), this paremeter restricts results to objects that match this ID.",
+                        "description": "If searching for Histories about specific objects (such as Users, or API Keys), this parameter restricts results to objects that match this ID.",
                         "example": "1",
-                        "x-ms-summary": "If searching for Histories about specific objects (such as Users, or API Keys), this paremeter restricts results to objects that match this ID."
+                        "x-ms-summary": "If searching for Histories about specific objects (such as Users, or API Keys), this parameter restricts results to objects that match this ID."
                     },
                     "query_target_name": {
                         "type": "string",
@@ -31097,9 +31097,9 @@
                     },
                     "query_target_permission": {
                         "type": "string",
-                        "description": "If searching for Histories about Permisisons, this parameter restricts results to permissions of this level.",
+                        "description": "If searching for Histories about Permissions, this parameter restricts results to permissions of this level.",
                         "example": "full",
-                        "x-ms-summary": "If searching for Histories about Permisisons, this parameter restricts results to permissions of this level."
+                        "x-ms-summary": "If searching for Histories about Permissions, this parameter restricts results to permissions of this level."
                     },
                     "query_target_user_id": {
                         "type": "string",
@@ -32387,7 +32387,7 @@
             "behavior": "remote_server_mount",
             "children_can_add": false,
             "children_can_override": false,
-            "docs": "Mount a remote server within this folder.  Remote servers can be FTP/SFTP servers, Amazon S3/GCP/Azure Blob/Wasabi/Backblaze B2 Buckets, and more.\n\nSee the RemoteServer object for a full list of the Remote Servers supported.\n\nWhen this behavior is enabled, files in this folder will never actually be stored on Files.com.  Rather, Files.com will mount the remote server and\nact as a mere conduit from your clients to the remote server.\n\nFiles.com workflow elements such as Permissions, Automations, Webhooks, Notifications, etc., will apply only to transfer activities that occur through\nFiles.com.  We won't send Webhooks or Notifications based on activity that occurs via a direct connetion to the Remote Server other than through Files.com.\n\n> Example Value\n\n```json\n<%=JSON.pretty_generate({\n  'remote_server_id' => '1',\n  'remote_path' => ''\n})%>\n```\n\nValue Hash Parameters | &nbsp;\n--- | ---\n`remote_server_id` | ID of the remote server to sync with.  See the Remote Servers API resource for managing these.\n`remote_path` | Path on remote server to treat as the root of this mount. This should be an absolute path on the remote server. This must be slash-delimited, but it must neither start nor end with a slash.\n",
+            "docs": "Mount a remote server within this folder.  Remote servers can be FTP/SFTP servers, Amazon S3/GCP/Azure Blob/Wasabi/Backblaze B2 Buckets, and more.\n\nSee the RemoteServer object for a full list of the Remote Servers supported.\n\nWhen this behavior is enabled, files in this folder will never actually be stored on Files.com.  Rather, Files.com will mount the remote server and\nact as a mere conduit from your clients to the remote server.\n\nFiles.com workflow elements such as Permissions, Automations, Webhooks, Notifications, etc., will apply only to transfer activities that occur through\nFiles.com.  We won't send Webhooks or Notifications based on activity that occurs via a direct connection to the Remote Server other than through Files.com.\n\n> Example Value\n\n```json\n<%=JSON.pretty_generate({\n  'remote_server_id' => '1',\n  'remote_path' => ''\n})%>\n```\n\nValue Hash Parameters | &nbsp;\n--- | ---\n`remote_server_id` | ID of the remote server to sync with.  See the Remote Servers API resource for managing these.\n`remote_path` | Path on remote server to treat as the root of this mount. This should be an absolute path on the remote server. This must be slash-delimited, but it must neither start nor end with a slash.\n",
             "requires_attachment": false,
             "supports_mounted_folders": true,
             "unique_per_folder": true,
@@ -32422,7 +32422,7 @@
         },
         {
             "type": "bad-request/cant-move-with-multiple-locations",
-            "title": "Cant Move With Multiple Locations",
+            "title": "Can't Move With Multiple Locations",
             "http-code": 400
         },
         {
@@ -32672,7 +32672,7 @@
         },
         {
             "type": "not-authorized/cant-act-for-other-user",
-            "title": "Cant Act For Other User",
+            "title": "Can't Act For Other User",
             "http-code": 403
         },
         {

--- a/core/dylib/src/main/java/ch/cyberduck/core/local/LaunchServicesQuarantineService.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/local/LaunchServicesQuarantineService.java
@@ -41,7 +41,7 @@ public final class LaunchServicesQuarantineService implements QuarantineService 
      *                  downloading the file again if the user chooses to view the origin URL while resolving a quarantine
      *                  warning.
      * @param dataUrl   The URL from which the data for the quarantined item data was
-     *                  actaully streamed or downloaded, if available
+     *                  actually streamed or downloaded, if available
      */
     @Override
     public void setQuarantine(final Local file, final String originUrl, final String dataUrl) throws LocalAccessDeniedException {

--- a/core/dylib/src/main/java/ch/cyberduck/core/sparkle/NotificationSparkleUpdateHandler.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/sparkle/NotificationSparkleUpdateHandler.java
@@ -48,7 +48,7 @@ public class NotificationSparkleUpdateHandler implements Handler, NotificationSe
 
     @Override
     public void callback(final String identifier) {
-        // If the notificaton is clicked on, make sure we bring the update in focus
+        // If the notification is clicked on, make sure we bring the update in focus
         // If the app is terminated while the notification is clicked on, this will launch the application and perform a new update check
         if("Updater".equals(identifier)) {
             updater.check(false);

--- a/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdater.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdater.java
@@ -46,7 +46,7 @@ public abstract class SPUUpdater extends NSObject {
     /**
      * This creates an updater, but to start it and schedule update checks -startUpdater: needs to be invoked first.
      *
-     * @param hostBundle        The bundle that should be targetted for updating.
+     * @param hostBundle        The bundle that should be targeted for updating.
      * @param applicationBundle The application bundle that should be waited for termination and relaunched (unless overridden). Usually this can be the same as hostBundle. This may differ when updating a plug-in or other non-application bundle.
      * @param userDriver        The user driver that Sparkle uses for user update interaction.
      * @param delegate          SPUUpdaterDelegate. The delegate for SPUUpdater.

--- a/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdater.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdater.java
@@ -80,7 +80,7 @@ public abstract class SPUUpdater extends NSObject {
     /**
      * Checks for updates, but does not display any UI unless an update is found.
      * <p>
-     * This is meant for programmatically initating a check for updates. That is,
+     * This is meant for programmatically initiating a check for updates. That is,
      * it will display no UI unless it actually finds an update, in which case it
      * proceeds as usual.
      * <p>

--- a/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdaterDelegate.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/sparkle/bindings/SPUUpdaterDelegate.java
@@ -94,7 +94,7 @@ public interface SPUUpdaterDelegate {
     }
 
     /**
-     * Called immediately after succesfull download of the specified update.
+     * Called immediately after successful download of the specified update.
      *
      * @param updater The SUUpdater instance.
      * @param item    The appcast item corresponding to the update that has been downloaded.

--- a/core/dylib/src/main/java/ch/cyberduck/core/threading/DispatchExecutorService.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/threading/DispatchExecutorService.java
@@ -266,7 +266,7 @@ public class DispatchExecutorService extends AbstractExecutorService {
 
         /**
          * Get the original <code>Runnable</code> used to create this task,
-         * will simply return <code>this</code> if the task was creaed with a
+         * will simply return <code>this</code> if the task was created with a
          * <code>Callable</code> instead.
          *
          * @return the original Runnable

--- a/core/dylib/src/main/java/ch/cyberduck/core/threading/WindowMainAction.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/threading/WindowMainAction.java
@@ -29,7 +29,7 @@ public abstract class WindowMainAction extends ControllerMainAction {
     }
 
     /**
-     * @return True if hte window is still on screen
+     * @return True if the window is still on screen
      */
     @Override
     public boolean isValid() {

--- a/core/src/main/java/ch/cyberduck/core/AbstractHostCollection.java
+++ b/core/src/main/java/ch/cyberduck/core/AbstractHostCollection.java
@@ -93,7 +93,7 @@ public abstract class AbstractHostCollection extends Collection<Host> implements
     /**
      * A bookmark may be member of multiple groups
      *
-     * @param groups Defines group critera for host
+     * @param groups Defines group criteria for host
      * @param filter Filter to apply to result set
      * @return Map of bookmarks grouped by labels
      */

--- a/core/src/main/java/ch/cyberduck/core/Controller.java
+++ b/core/src/main/java/ch/cyberduck/core/Controller.java
@@ -32,7 +32,7 @@ public interface Controller extends ProgressListener, TranscriptListener, Backgr
     /**
      * Will queue up the <code>BackgroundAction</code> to be run in a background thread. Will be executed
      * as soon as no other previous <code>BackgroundAction</code> is pending.
-     * Will return immediatly but not run the runnable before the lock of the runnable is acquired.
+     * Will return immediately but not run the runnable before the lock of the runnable is acquired.
      *
      * @param runnable The runnable to execute in a secondary Thread
      * @return Future result

--- a/core/src/main/java/ch/cyberduck/core/Host.java
+++ b/core/src/main/java/ch/cyberduck/core/Host.java
@@ -704,7 +704,7 @@ public class Host implements Serializable, Comparable<Host> {
             }
         },
         /**
-         * Single connnection in Transfer window
+         * Single connection in Transfer window
          */
         newconnection {
             @Override

--- a/core/src/main/java/ch/cyberduck/core/LoginService.java
+++ b/core/src/main/java/ch/cyberduck/core/LoginService.java
@@ -29,10 +29,10 @@ public interface LoginService {
      * Obtain password from keychain or prompt panel
      *
      * @param bookmark Credentials
-     * @param pompt    Login prompt
+     * @param prompt    Login prompt
      * @param options  Login mechanism features
      */
-    void validate(Host bookmark, LoginCallback pompt, LoginOptions options) throws ConnectionCanceledException, LoginFailureException;
+    void validate(Host bookmark, LoginCallback prompt, LoginOptions options) throws ConnectionCanceledException, LoginFailureException;
 
     /**
      * Login and prompt on failure

--- a/core/src/main/java/ch/cyberduck/core/Navigation.java
+++ b/core/src/main/java/ch/cyberduck/core/Navigation.java
@@ -47,7 +47,7 @@ public class Navigation {
     }
 
     /**
-     * Returns the prevously browsed path and moves it to the forward history
+     * Returns the previously browsed path and moves it to the forward history
      *
      * @return The previously browsed path or null if there is none
      */

--- a/core/src/main/java/ch/cyberduck/core/cdn/Distribution.java
+++ b/core/src/main/java/ch/cyberduck/core/cdn/Distribution.java
@@ -108,7 +108,7 @@ public class Distribution {
     private String status;
 
     /**
-     * CNAME DNS entires to the CDN hostname
+     * CNAME DNS entries to the CDN hostname
      */
     private String[] cnames;
 

--- a/core/src/main/java/ch/cyberduck/core/features/Bulk.java
+++ b/core/src/main/java/ch/cyberduck/core/features/Bulk.java
@@ -24,7 +24,7 @@ import ch.cyberduck.core.transfer.TransferStatus;
 import java.util.Map;
 
 /**
- * Alllow to invoke any action required before or after a file transfer
+ * Allow to invoke any action required before or after a file transfer
  */
 @Optional
 public interface Bulk<R> {

--- a/core/src/main/java/ch/cyberduck/core/io/AbstractChecksumCompute.java
+++ b/core/src/main/java/ch/cyberduck/core/io/AbstractChecksumCompute.java
@@ -35,7 +35,7 @@ import java.security.NoSuchAlgorithmException;
 
 public abstract class AbstractChecksumCompute implements ChecksumCompute {
 
-    protected byte[] digest(final String algorithm, final InputStream in, final StreamCancelation cancelation)
+    protected byte[] digest(final String algorithm, final InputStream in, final StreamCancelation cancellation)
             throws ConnectionCanceledException, ChecksumException {
         final MessageDigest md;
         try {
@@ -44,16 +44,16 @@ public abstract class AbstractChecksumCompute implements ChecksumCompute {
         catch(NoSuchAlgorithmException e) {
             throw new ChecksumException(e);
         }
-        return this.digest(in, md, cancelation);
+        return this.digest(in, md, cancellation);
     }
 
-    protected byte[] digest(final InputStream in, final MessageDigest md, final StreamCancelation cancelation)
+    protected byte[] digest(final InputStream in, final MessageDigest md, final StreamCancelation cancellation)
             throws ConnectionCanceledException, ChecksumException {
         try {
             byte[] buffer = new byte[16384];
             int bytesRead;
             while((bytesRead = in.read(buffer, 0, buffer.length)) != -1) {
-                cancelation.validate();
+                cancellation.validate();
                 md.update(buffer, 0, bytesRead);
             }
         }

--- a/core/src/main/java/ch/cyberduck/core/io/BufferSegmentingOutputStream.java
+++ b/core/src/main/java/ch/cyberduck/core/io/BufferSegmentingOutputStream.java
@@ -47,7 +47,7 @@ public class BufferSegmentingOutputStream extends SegmentingOutputStream {
             log.debug(String.format("Copy buffer %s to output %s", buffer, proxy));
         }
         IOUtils.copy(new BufferInputStream(buffer), proxy);
-        // Re-use buffer
+        // Reuse buffer
         buffer.truncate(0L);
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/io/ChecksumCompute.java
+++ b/core/src/main/java/ch/cyberduck/core/io/ChecksumCompute.java
@@ -38,7 +38,7 @@ public interface ChecksumCompute {
      * @param status Offset and limit to read from stream
      * @return Calculated fingerprint
      * @throws ChecksumException         Error calculating checksum
-     * @throws ChecksumCanceledException Calculating checksum was interrrupted
+     * @throws ChecksumCanceledException Calculating checksum was interrupted
      */
     Checksum compute(InputStream in, TransferStatus status) throws BackgroundException;
 
@@ -46,7 +46,7 @@ public interface ChecksumCompute {
      * @param data Hex encoded string
      * @return Calculated fingerprint
      * @throws ChecksumException         Error calculating checksum
-     * @throws ChecksumCanceledException Calculating checksum was interrrupted
+     * @throws ChecksumCanceledException Calculating checksum was interrupted
      */
     default Checksum compute(final String data) throws BackgroundException {
         try {

--- a/core/src/main/java/ch/cyberduck/core/io/MD5FastChecksumCompute.java
+++ b/core/src/main/java/ch/cyberduck/core/io/MD5FastChecksumCompute.java
@@ -41,7 +41,7 @@ public class MD5FastChecksumCompute extends AbstractChecksumCompute {
                 this.normalize(in, status), status));
     }
 
-    protected byte[] digest(final String algorithm, final InputStream in, final StreamCancelation cancelation) throws ChecksumException, ChecksumCanceledException {
+    protected byte[] digest(final String algorithm, final InputStream in, final StreamCancelation cancellation) throws ChecksumException, ChecksumCanceledException {
         final MD5 md = new MD5();
         try {
             byte[] buffer = new byte[16384];

--- a/core/src/main/java/ch/cyberduck/core/io/MemorySegementingOutputStream.java
+++ b/core/src/main/java/ch/cyberduck/core/io/MemorySegementingOutputStream.java
@@ -64,7 +64,7 @@ public class MemorySegementingOutputStream extends SegmentingOutputStream {
     protected void flush(final boolean force) throws IOException {
         // Copy from memory file to output
         final byte[] content = buffer.toByteArray();
-        // Re-use buffer
+        // Reuse buffer
         buffer.reset();
         for(int offset = 0; offset < content.length; offset += threshold) {
             int len = Math.min(threshold, content.length - offset);
@@ -90,7 +90,7 @@ public class MemorySegementingOutputStream extends SegmentingOutputStream {
             if(buffer.size() > 0) {
                 proxy.write(buffer.toByteArray());
             }
-            // Re-use buffer
+            // Reuse buffer
             buffer.reset();
             super.close();
         }

--- a/core/src/main/java/ch/cyberduck/core/io/StreamGobbler.java
+++ b/core/src/main/java/ch/cyberduck/core/io/StreamGobbler.java
@@ -14,7 +14,7 @@ import java.io.InterruptedIOException;
  * This class is sometimes very convenient - if you wrap a session's STDOUT and STDERR
  * InputStreams with instances of this class, then you don't have to bother about
  * the shared window of STDOUT and STDERR in the low level SSH-2 protocol,
- * since all arriving data will be immediatelly consumed by the worker threads.
+ * since all arriving data will be immediately consumed by the worker threads.
  * Also, as a side effect, the streams will be buffered (e.g., single byte
  * read() operations are faster).
  * <p/>

--- a/core/src/main/java/ch/cyberduck/core/local/ApplicationFinder.java
+++ b/core/src/main/java/ch/cyberduck/core/local/ApplicationFinder.java
@@ -40,7 +40,7 @@ public interface ApplicationFinder {
 
     /**
      * @param application Application description
-     * @return True if path to the applicaiton is found. False if the application is not installed
+     * @return True if path to the application is found. False if the application is not installed
      */
     boolean isInstalled(Application application);
 

--- a/core/src/main/java/ch/cyberduck/core/local/ApplicationLauncher.java
+++ b/core/src/main/java/ch/cyberduck/core/local/ApplicationLauncher.java
@@ -49,7 +49,7 @@ public interface ApplicationLauncher {
     boolean open(Application application, String args);
 
     /**
-     * Post notifiation for file
+     * Post notification for file
      *
      * @param file File on disk
      */

--- a/core/src/main/java/ch/cyberduck/core/preferences/MigratingSupportDirectoryFinder.java
+++ b/core/src/main/java/ch/cyberduck/core/preferences/MigratingSupportDirectoryFinder.java
@@ -36,7 +36,7 @@ public class MigratingSupportDirectoryFinder implements SupportDirectoryFinder {
     private final SupportDirectoryFinder proxy;
 
     /**
-     * @param deprecated Deprecated implemenation providing previous application support folder
+     * @param deprecated Deprecated implementation providing previous application support folder
      */
     public MigratingSupportDirectoryFinder(final SupportDirectoryFinder deprecated, final SupportDirectoryFinder proxy) {
         this.deprecated = deprecated;

--- a/core/src/main/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorker.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorker.java
@@ -90,7 +90,7 @@ public class ProfilesSynchronizeWorker extends Worker<Set<ProfileDescription>> {
             final Optional<ProfileDescription> match = matcher.compare(local);
             if(match.isPresent()) {
                 // Found matching checksum for profile in remote list which is not marked as latest version
-                log.warn(String.format("Override %s with latest profile verison %s", local, match));
+                log.warn(String.format("Override %s with latest profile version %s", local, match));
                 // Remove previous version
                 local.getProfile().ifPresent(registry::unregister);
                 // Register updated profile by copying temporary file to application support

--- a/core/src/main/java/ch/cyberduck/core/threading/ControllerMainAction.java
+++ b/core/src/main/java/ch/cyberduck/core/threading/ControllerMainAction.java
@@ -29,7 +29,7 @@ public abstract class ControllerMainAction extends MainAction {
     }
 
     /**
-     * @return True if hte window is still on screen
+     * @return True if the window is still on screen
      */
     @Override
     public boolean isValid() {

--- a/core/src/main/java/ch/cyberduck/core/transfer/Transfer.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/Transfer.java
@@ -333,7 +333,7 @@ public abstract class Transfer implements Serializable {
     /**
      * @param source      Connection to source server of transfer. May be null.
      * @param destination Connection to target server of transfer
-     * @param files       Files transfered
+     * @param files       Files transferred
      * @param error       Error callback
      * @param listener    Listener
      * @param callback    Prompt

--- a/core/src/main/java/ch/cyberduck/core/transfer/TransferAction.java
+++ b/core/src/main/java/ch/cyberduck/core/transfer/TransferAction.java
@@ -183,7 +183,7 @@ public abstract class TransferAction {
     };
 
     /**
-     * Automatically decide the transfer action using the comparision service for paths.
+     * Automatically decide the transfer action using the comparison service for paths.
      */
     public static final TransferAction comparison = new TransferAction("compare") {
         @Override

--- a/core/src/main/java/ch/cyberduck/core/updater/UpdateChecker.java
+++ b/core/src/main/java/ch/cyberduck/core/updater/UpdateChecker.java
@@ -45,7 +45,7 @@ public interface UpdateChecker {
          * Handle update found
          *
          * @param item Update description
-         * @return True if standard driver should not continue handling update or false if no additinal prompt for update is shown
+         * @return True if standard driver should not continue handling update or false if no additional prompt for update is shown
          */
         boolean handle(UpdateChecker.Update item);
     }

--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -325,7 +325,7 @@ s3.upload.multipart.partsize.minimum=5242880
 # Threshold in bytes. Only use multipart uploads for files more than 100MB
 s3.upload.multipart.threshold=104857600
 s3.upload.multipart.required.threshold=5368709120
-# Maximum number of parts is 10'000. With 10MB segements this gives a maximum object size of 100GB
+# Maximum number of parts is 10'000. With 10MB segments this gives a maximum object size of 100GB
 # Must be a multiple of org.cryptomator.cryptolib.v1.Constants.PAYLOAD_SIZE when using Cryptomator Vaults
 # 10MB
 s3.upload.multipart.size=10485760

--- a/dracoon/src/main/java/ch/cyberduck/core/sds/SDSUploadService.java
+++ b/dracoon/src/main/java/ch/cyberduck/core/sds/SDSUploadService.java
@@ -84,7 +84,7 @@ public class SDSUploadService {
     /**
      * @param file   Remote path
      * @param status Length and modification date for file uploaded
-     * @return Uplaod URI
+     * @return Upload URI
      */
     public CreateFileUploadResponse start(final Path file, final TransferStatus status) throws BackgroundException {
         try {

--- a/eue/src/main/resources/api.yaml
+++ b/eue/src/main/resources/api.yaml
@@ -906,7 +906,7 @@ components:
                 properties:
                     forceOverwrite:
                         type: boolean
-                    ovewrite:
+                    overwrite:
                         type: boolean
                     path:
                         type: string

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/list/FTPListResponseReader.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/list/FTPListResponseReader.java
@@ -51,7 +51,7 @@ public class FTPListResponseReader implements FTPDataResponseReader {
         final AttributedList<Path> children = new AttributedList<Path>();
         // At least one entry successfully parsed
         boolean success = false;
-        // Call hook for those implementors which need to perform some action upon the list after it has been created
+        // Call hook for those implementers which need to perform some action upon the list after it has been created
         // from the server stream, but before any clients see the list
         parser.preParse(replies);
         for(String line : replies) {

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/parser/CompositeFileEntryParser.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/parser/CompositeFileEntryParser.java
@@ -14,7 +14,7 @@ import java.util.List;
  * This implementation allows to pack some FileEntryParsers together
  * and handle the case where to returned dirstyle isn't clearly defined.
  * The matching parser will be cached.
- * If the cached parser wont match due to the server changed the dirstyle,
+ * If the cached parser won't match due to the server changed the dirstyle,
  * a new matching parser will be searched.
  *
  * @author Mario Ivankovits <mario@ops.co.at>

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/parser/RumpusFTPEntryParser.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/parser/RumpusFTPEntryParser.java
@@ -60,7 +60,7 @@ public class RumpusFTPEntryParser extends CommonUnixFTPEntryParser {
     /**
      * The default constructor for a UnixFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable.  Should not be seen
+     * @throws IllegalArgumentException Thrown if the regular expression is unparsable.  Should not be seen
      *                                  under normal conditions.  It it is seen, this is a sign that
      *                                  <code>REGEX</code> is  not a valid regular expression.
      */

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/FTPReadFeatureTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/FTPReadFeatureTest.java
@@ -114,7 +114,7 @@ public class FTPReadFeatureTest extends AbstractFTPTest {
         new DefaultTouchFeature<>(new FTPWriteFeature(session)).touch(file, new TransferStatus());
         final InputStream in = new FTPReadFeature(session).read(file, status, new DisabledConnectionCallback());
         assertNotNull(in);
-        // Send ABOR because stream was not read completly
+        // Send ABOR because stream was not read completely
         in.close();
         // Make sure subsequent PWD command works
         assertEquals(workdir, new FTPWorkdirService(session).find());
@@ -136,7 +136,7 @@ public class FTPReadFeatureTest extends AbstractFTPTest {
         final InputStream in = new FTPReadFeature(session).read(test, status, new DisabledConnectionCallback());
         assertNotNull(in);
         assertTrue(in.read() > 0);
-        // Send ABOR because stream was not read completly
+        // Send ABOR because stream was not read completely
         in.close();
         // Make sure subsequent PWD command works
         assertEquals(workdir, new FTPWorkdirService(session).find());

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReaderTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/list/FTPMlsdListResponseReaderTest.java
@@ -279,7 +279,7 @@ public class FTPMlsdListResponseReaderTest {
         Path path = new Path("/www", EnumSet.of(Path.Type.directory));
         String[] replies = new String[]{
                 "type=dir;modify=20140315210350; Gozo 2013/2014",
-                "type=dir;modify=20140315210350; Tigger & Friends"
+                "type=dir;modify=20140315210350; Trigger & Friends"
         };
         final AttributedList<Path> children = new FTPMlsdListResponseReader()
                 .read(path, Arrays.asList(replies));

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/AXSPortFTPEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/AXSPortFTPEntryParserTest.java
@@ -29,7 +29,7 @@ public class AXSPortFTPEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("CMX TCP/IP - REMOTE FTP server (version 2.0) ready.");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/EPLFEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/EPLFEntryParserTest.java
@@ -17,7 +17,7 @@ public class EPLFEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("UNIX");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/FilezillaFTPEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/FilezillaFTPEntryParserTest.java
@@ -34,7 +34,7 @@ public class FilezillaFTPEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("UNIX emulated by FileZilla");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/FreeboxFTPEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/FreeboxFTPEntryParserTest.java
@@ -34,7 +34,7 @@ public class FreeboxFTPEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("MACOS");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/HPTru64ParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/HPTru64ParserTest.java
@@ -34,7 +34,7 @@ public class HPTru64ParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("UNIX");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/NetwareFTPEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/NetwareFTPEntryParserTest.java
@@ -35,7 +35,7 @@ public class NetwareFTPEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("NETWARE  Type : L8");
     }
 

--- a/ftp/src/test/java/ch/cyberduck/core/ftp/parser/WebstarFTPEntryParserTest.java
+++ b/ftp/src/test/java/ch/cyberduck/core/ftp/parser/WebstarFTPEntryParserTest.java
@@ -34,7 +34,7 @@ public class WebstarFTPEntryParserTest {
     private FTPFileEntryParser parser;
 
     @Before
-    public void conigure() {
+    public void configure() {
         this.parser = new FTPParserSelector().getParser("MACOS WebSTAR FTP");
     }
 

--- a/importer/src/test/java/ch/cyberduck/core/importer/TotalCommanderBookmarkCollectionTest.java
+++ b/importer/src/test/java/ch/cyberduck/core/importer/TotalCommanderBookmarkCollectionTest.java
@@ -46,7 +46,7 @@ public class TotalCommanderBookmarkCollectionTest {
         c.parse(new ProtocolFactory(new HashSet<>(Arrays.asList(new TestProtocol(Scheme.ftp), new TestProtocol(Scheme.ftps), new TestProtocol(Scheme.sftp)))), new Local("src/test/resources/wcx_ftp.ini"));
         assertEquals(2, c.size());
         assertEquals("sudo.ch", c.get(0).getHostname());
-        assertEquals("fo|cyberduck.io session bookmark", c.get(1).getNickname());
+        assertEquals("fo|cyberduck.io session bookmark", c.get(1).getNickname());  /* pragma: codespell-ignore */
         assertEquals("cyberduck.io", c.get(1).getHostname());
         assertEquals("/remote", c.get(1).getDefaultPath());
     }

--- a/nextcloud/src/main/java/ch/cyberduck/core/nextcloud/NextcloudAttributesFinderFeature.java
+++ b/nextcloud/src/main/java/ch/cyberduck/core/nextcloud/NextcloudAttributesFinderFeature.java
@@ -51,7 +51,7 @@ public class NextcloudAttributesFinderFeature extends DAVAttributesFinderFeature
      * W: Updateable (file)
      * CK: Creatable (folders only)
      * Z: Deniable
-     * P: Trashbin Purgable
+     * P: Trashbin Purgeable
      */
     public static final QName OC_PERMISSIONS_CUSTOM_NAMESPACE = new QName(CUSTOM_NAMESPACE_URI, "permissions", CUSTOM_NAMESPACE_PREFIX);
     /**

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/OneDriveSession.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/OneDriveSession.java
@@ -95,7 +95,7 @@ public class OneDriveSession extends GraphSession {
         if(new SimplePathPredicate(OneDriveListService.MYFILES_NAME).test(file)) {
             final User.Metadata user = this.getUser();
             // creationType can be non-assigned (Microsoft Account)
-            // or null, Inviation, LocalAccount or EmailVerified.
+            // or null, Invitation, LocalAccount or EmailVerified.
             // noinspection OptionalAssignedToNull
             if(null == user || user.getCreationType() == null) {
                 return new Drive(client).getRoot();

--- a/openstack/src/main/java/ch/cyberduck/core/openstack/SwiftAccountLoader.java
+++ b/openstack/src/main/java/ch/cyberduck/core/openstack/SwiftAccountLoader.java
@@ -61,7 +61,7 @@ public class SwiftAccountLoader extends OneTimeSchedulerFeature<Map<Region, Acco
                     try {
                         final String key = new AsciiRandomStringService().random();
                         if(log.isDebugEnabled()) {
-                            log.debug(String.format("Set acccount temp URL key to %s", key));
+                            log.debug(String.format("Set account temp URL key to %s", key));
                         }
                         session.getClient().updateAccountMetadata(region, Collections.singletonMap("X-Account-Meta-Temp-URL-Key", key));
                         info.setTempUrlKey(key);

--- a/openstack/src/main/java/ch/cyberduck/core/openstack/SwiftSegmentService.java
+++ b/openstack/src/main/java/ch/cyberduck/core/openstack/SwiftSegmentService.java
@@ -59,7 +59,7 @@ public class SwiftSegmentService {
             = new ISO8601DateFormatter();
 
     /**
-     * Segement files prefix
+     * Segment files prefix
      */
     private final String prefix;
 

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/ApplicationUserDefaultsPreferences.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/ApplicationUserDefaultsPreferences.java
@@ -76,7 +76,7 @@ public class ApplicationUserDefaultsPreferences extends ApplicationPreferences {
         this.setDefault("website.store", "macappstore://itunes.apple.com/app/id409222199?mt=12");
 
         if(new FinderLocal("~/Downloads").exists()) {
-            // For 10.5+ this usually exists and should be preferrred
+            // For 10.5+ this usually exists and should be preferred
             this.setDefault("queue.download.folder", "~/Downloads");
         }
         else {

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BrowserController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/BrowserController.java
@@ -1881,7 +1881,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
         final Host selected = bookmarkModel.getSource().get(bookmarkTable.selectedRow().intValue());
         this.selectBookmarks(BookmarkSwitchSegement.bookmarks);
         final Host duplicate = new HostDictionary<>().deserialize(selected.serialize(SerializerFactory.get()));
-        // Make sure a new UUID is asssigned for duplicate
+        // Make sure a new UUID is assigned for duplicate
         duplicate.setUuid(null);
         this.addBookmark(duplicate);
     }
@@ -1903,7 +1903,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
                 selected = workdir;
             }
             bookmark = new HostDictionary<>().deserialize(pool.getHost().serialize(SerializerFactory.get()));
-            // Make sure a new UUID is asssigned for duplicate
+            // Make sure a new UUID is assigned for duplicate
             bookmark.setUuid(null);
             bookmark.setDefaultPath(selected.getAbsolute());
         }
@@ -3606,7 +3606,7 @@ public class BrowserController extends WindowController implements NSToolbar.Del
     }
 
     /**
-     * Overrriden to remove any listeners from the session
+     * Overridden to remove any listeners from the session
      */
     @Override
     public void invalidate() {

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/MainController.java
@@ -1138,7 +1138,7 @@ public class MainController extends BundleController implements NSApplication.De
                         return NSApplication.NSTerminateLater;
                     }
                     if(choice == SheetCallback.DEFAULT_OPTION) {
-                        // Quit immediatly
+                        // Quit immediately
                         return this.applicationShouldTerminateAfterDonationPrompt(app);
                     }
                 }
@@ -1219,7 +1219,7 @@ public class MainController extends BundleController implements NSApplication.De
 
     @Action
     public void applicationWillRestartAfterUpdate(ID updater) {
-        // Disable donation prompt after udpate install
+        // Disable donation prompt after update install
         displayDonationPrompt = false;
     }
 
@@ -1341,7 +1341,7 @@ public class MainController extends BundleController implements NSApplication.De
 
     /**
      * Posted before a user session is switched out. This allows an application to disable some processing when its user
-     * session is switched out, and reenable when that session gets switched back in, for example.
+     * session is switched out, and re-enable when that session gets switched back in, for example.
      *
      * @param notification Notification name
      */

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/datasource/BrowserListViewDataSource.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/datasource/BrowserListViewDataSource.java
@@ -100,7 +100,7 @@ public class BrowserListViewDataSource extends BrowserTableDataSource implements
                 }
                 return super.validateDrop(view, destination, row, draggingInfo);
             }
-            // Draging to empty area in browser
+            // Dragging to empty area in browser
             return super.validateDrop(view, destination, row, draggingInfo);
         }
         // Passing to super to look for URLs to mount

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/AbstractMenuDelegate.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/AbstractMenuDelegate.java
@@ -150,7 +150,7 @@ public abstract class AbstractMenuDelegate extends ProxyController implements NS
     /**
      * @return Separator menu item
      */
-    protected NSMenuItem seperator() {
+    protected NSMenuItem separator() {
         return NSMenuItem.separatorItem();
     }
 

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/AbstractMenuDelegate.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/AbstractMenuDelegate.java
@@ -100,7 +100,7 @@ public abstract class AbstractMenuDelegate extends ProxyController implements NS
     }
 
     /**
-     * @return True if this menu has an item that has registerd a keyboard shortcut
+     * @return True if this menu has an item that has registered a keyboard shortcut
      *         equivalent to the event characters.
      */
     public boolean menuHasKeyEquivalent_forEvent(NSMenu menu, NSEvent event) {

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/HistoryMenuDelegate.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/delegate/HistoryMenuDelegate.java
@@ -141,7 +141,7 @@ public class HistoryMenuDelegate extends CollectionMenuDelegate<Host> {
         }
         else if(row.intValue() == size) {
             menu.removeItemAtIndex(row);
-            menu.insertItem_atIndex(this.seperator(), row);
+            menu.insertItem_atIndex(this.separator(), row);
         }
         else if(row.intValue() == size + 1) {
             item.setTitle(LocaleFactory.localizedString("Clear Menu"));

--- a/s3/src/main/java/ch/cyberduck/core/s3/S3VersioningFeature.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3VersioningFeature.java
@@ -90,7 +90,7 @@ public class S3VersioningFeature implements Versioning {
                 }
                 if(configuration.isEnabled() && !configuration.isMultifactor()) {
                     log.debug(String.format("Disable MFA %s for %s", factor.getUsername(), bucket));
-                    // User has choosen to disable MFA
+                    // User has chosen to disable MFA
                     final Credentials factor2 = this.getToken(prompt);
                     session.getClient().disableMFAForVersionedBucket(bucket.isRoot() ? StringUtils.EMPTY : bucket.getName(),
                             factor2.getUsername(), factor2.getPassword());

--- a/s3/src/test/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorkerTest.java
+++ b/s3/src/test/java/ch/cyberduck/core/profiles/ProfilesSynchronizeWorkerTest.java
@@ -48,7 +48,7 @@ public class ProfilesSynchronizeWorkerTest {
 
     @Test
     public void testRunCloudfrontEndpoint() throws Exception {
-        // Registry in temparary folder
+        // Registry in temporary folder
         final ProtocolFactory protocols = new ProtocolFactory(new HashSet<>(Collections.singletonList(new S3Protocol())));
         final Host host = new HostParser(protocols, new S3Protocol()).get("s3://djynunjb246r8.cloudfront.net").withCredentials(
                 new Credentials(PreferencesFactory.get().getProperty("connection.login.anon.name")));
@@ -96,7 +96,7 @@ public class ProfilesSynchronizeWorkerTest {
 
     @Test
     public void testRunVirtualHostEndpoint() throws Exception {
-        // Registry in temparary folder
+        // Registry in temporary folder
         final ProtocolFactory protocols = new ProtocolFactory(new HashSet<>(Collections.singletonList(new S3Protocol())));
         final Host host = new HostParser(protocols, new S3Protocol()).get("s3:/profiles.cyberduck.io").withCredentials(
                 new Credentials(PreferencesFactory.get().getProperty("connection.login.anon.name")));

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/PreferencesHostKeyVerifier.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/PreferencesHostKeyVerifier.java
@@ -46,7 +46,7 @@ public abstract class PreferencesHostKeyVerifier extends AbstractHostKeyCallback
     public boolean verify(final Host host, final PublicKey key) throws BackgroundException {
         String lookup = preferences.getProperty(this.toFormat(host, key));
         if(StringUtils.isEmpty(lookup)) {
-            // Backward compatiblity to find keys with no port number saved
+            // Backward compatibility to find keys with no port number saved
             lookup = preferences.getProperty(this.toFormat(host, key, false));
         }
         if(StringUtils.equals(Base64.toBase64String(key.getEncoded()), lookup)) {

--- a/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateAttributesFinderFeature.java
+++ b/storegate/src/main/java/ch/cyberduck/core/storegate/StoregateAttributesFinderFeature.java
@@ -97,7 +97,7 @@ public class StoregateAttributesFinderFeature implements AttributesFinder, Attri
             // NoAccess	0
             // ReadOnly	 1
             // ReadWrite 2
-            // Synchronize	4	Read, write access and permission to syncronize using desktop client.
+            // Synchronize	4	Read, write access and permission to synchronize using desktop client.
             // FullControl 99
             final Permission permission;
             if((f.getPermission() & 2) == 2 || (f.getPermission() & 4) == 4) {

--- a/www/update/changelog.html
+++ b/www/update/changelog.html
@@ -103,7 +103,7 @@
     <a target="_blank" href="https://trac.cyberduck.io/milestone/8.7.2"><strong>Version 8.7.2</strong></a>
 </p>
 <ul data-sparkle-version="8.7.2">
-    <li><span class="label label-warning">Bugfix</span> Missing digest header when commiting large file upload (Box) (<a
+    <li><span class="label label-warning">Bugfix</span> Missing digest header when committing large file upload (Box) (<a
             target="_blank" href="https://trac.cyberduck.io/ticket/14564">#14564</a>)
     </li>
     <li><span class="label label-warning">Bugfix</span> Modification date not set in upload (Dropbox) (<a
@@ -654,7 +654,7 @@
     <a target="_blank" href="https://trac.cyberduck.io/milestone/8.3.3"><strong>Version 8.3.3</strong></a>
 </p>
 <ul data-sparkle-version="8.3.3">
-    <li><span class="label label-warning">Bugfix</span> Failing transfers with multipe files (FTP) (<a
+    <li><span class="label label-warning">Bugfix</span> Failing transfers with multiple files (FTP) (<a
             target="_blank" href="https://trac.cyberduck.io/ticket/13322">#13322</a>)
     </li>
 </ul>


### PR DESCRIPTION
This is my way to contribute back to projects I touch to use or told about (thus popular).

codespell: https://github.com/codespell-project/codespell to discover more


I spotted some code changes - but all looked good to be changed, but please review more.

I ignored 'unsecure'  in a config setting `connection.unsecure` to not cause disturbance. 

You can annotate lines to be ignored with e.g. `/* pragma: codespell-ignore */` so you could even add suggestions right here in the diff as suggestions to expedite reversion back if needed.