### PR TITLE
The implementation now uses the posix-rename OpenSSH extension when a…

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPMoveFeature.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPMoveFeature.java
@@ -46,7 +46,7 @@ public class SFTPMoveFeature implements Move {
             if(status.isExists()) {
                 delete.delete(Collections.singletonMap(renamed, status), connectionCallback, callback);
             }
-            session.sftp().rename(file.getAbsolute(), renamed.getAbsolute(), Collections.singleton(RenameFlags.OVERWRITE));
+            session.sftp().rename(file.getAbsolute(), renamed.getAbsolute(), Collections.singleton(status.isExists() ? RenameFlags.OVERWRITE : RenameFlags.NATIVE));
             // Copy original file attributes
             return renamed.withAttributes(file.attributes());
         }


### PR DESCRIPTION
…vailable for SFTP protocol versions 3 or 4 when overwrite flag is set only.

Regression from 0a593520.