### PR TITLE
Do not add bearer authorization for pre-authenticated download URLs.

### DIFF
--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphSession.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphSession.java
@@ -62,6 +62,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.http.client.protocol.HttpClientContext.REDIRECT_LOCATIONS;
+
 public abstract class GraphSession extends HttpSession<OneDriveAPI> {
     private static final Logger log = LogManager.getLogger(GraphSession.class);
 
@@ -135,7 +137,12 @@ public abstract class GraphSession extends HttpSession<OneDriveAPI> {
             @Override
             public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
                 if(request.containsHeader(HttpHeaders.AUTHORIZATION)) {
-                    super.process(request, context);
+                    if(context.getAttribute(REDIRECT_LOCATIONS) == null) {
+                        super.process(request, context);
+                    }
+                    else {
+                        request.removeHeaders(HttpHeaders.AUTHORIZATION);
+                    }
                 }
             }
         }.withRedirectUri(host.getProtocol().getOAuthRedirectUrl())


### PR DESCRIPTION
For some endpoints requests to download content that include bearer authentication fail with `403`.

> Preauthenticated download URLs are only valid for a short period of time (a few minutes) and don't require an Authorization header to download. [^1]

[^1]: https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http#response 