### PR TITLE
Only share context in subsequent logical requests

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/http/DelayedHttpEntity.java
+++ b/core/src/main/java/ch/cyberduck/core/http/DelayedHttpEntity.java
@@ -67,17 +67,12 @@ public abstract class DelayedHttpEntity extends AbstractHttpEntity {
     private OutputStream stream;
 
     /**
-     * Entity written to server
-     */
-    private boolean entityWritten = false;
-
-    /**
      * Parent thread to check if still alive
      */
     private final Thread parentThread;
 
     public boolean isRepeatable() {
-        return !entityWritten;
+        return false;
     }
 
     public abstract long getContentLength();
@@ -120,12 +115,10 @@ public abstract class DelayedHttpEntity extends AbstractHttpEntity {
         }
         // Wait for signal when content has been written to the pipe
         Interruptibles.await(streamClosed, IOException.class, new Interruptibles.ThreadAliveCancelCallback(parentThread));
-        // Entity written to server
-        entityWritten = true;
     }
 
     public boolean isStreaming() {
-        return !entityWritten;
+        return true;
     }
 
     /**

--- a/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
+++ b/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
@@ -184,7 +184,7 @@ public class HttpConnectionPoolBuilder {
         if(!new HostPreferences(host).getBoolean("http.compression.enable")) {
             configuration.disableContentCompression();
         }
-        configuration.setRequestExecutor(new LoggingHttpRequestExecutor(listener));
+        configuration.setRequestExecutor(new CustomHttpRequestExecutor(host, listener));
         // Always register HTTP for possible use with proxy. Contains a number of protocol properties such as the
         // default port and the socket factory to be used to create the java.net.Socket instances for the given protocol
         final PoolingHttpClientConnectionManager connectionManager = this.createConnectionManager(this.createRegistry());

--- a/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
+++ b/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
@@ -53,8 +53,10 @@ import org.apache.http.impl.auth.NTLMSchemeFactory;
 import org.apache.http.impl.auth.SPNegoSchemeFactory;
 import org.apache.http.impl.client.AIMDBackoffManager;
 import org.apache.http.impl.client.DefaultClientConnectionReuseStrategy;
+import org.apache.http.impl.client.DefaultUserTokenHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.NoopUserTokenHandler;
 import org.apache.http.impl.client.WinHttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
@@ -172,6 +174,12 @@ public class HttpConnectionPoolBuilder {
         }
         else {
             configuration.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
+        }
+        if(new HostPreferences(host).getBoolean("http.connections.tokenhandler.enable")) {
+            configuration.setUserTokenHandler(DefaultUserTokenHandler.INSTANCE);
+        }
+        else {
+            configuration.setUserTokenHandler(NoopUserTokenHandler.INSTANCE);
         }
         // Retry handler for I/O failures
         configuration.setRetryHandler(new ExtendedHttpRequestRetryHandler(

--- a/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
+++ b/core/src/main/java/ch/cyberduck/core/http/HttpConnectionPoolBuilder.java
@@ -53,10 +53,8 @@ import org.apache.http.impl.auth.NTLMSchemeFactory;
 import org.apache.http.impl.auth.SPNegoSchemeFactory;
 import org.apache.http.impl.client.AIMDBackoffManager;
 import org.apache.http.impl.client.DefaultClientConnectionReuseStrategy;
-import org.apache.http.impl.client.DefaultUserTokenHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.client.NoopUserTokenHandler;
 import org.apache.http.impl.client.WinHttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
@@ -175,11 +173,8 @@ public class HttpConnectionPoolBuilder {
         else {
             configuration.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
         }
-        if(new HostPreferences(host).getBoolean("http.connections.tokenhandler.enable")) {
-            configuration.setUserTokenHandler(DefaultUserTokenHandler.INSTANCE);
-        }
-        else {
-            configuration.setUserTokenHandler(NoopUserTokenHandler.INSTANCE);
+        if(!new HostPreferences(host).getBoolean("http.connections.state.enable")) {
+            configuration.disableConnectionState();
         }
         // Retry handler for I/O failures
         configuration.setRetryHandler(new ExtendedHttpRequestRetryHandler(

--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -236,6 +236,7 @@ http.compression.enable=true
 # Integer.MAX_VALUE
 http.connections.route=2147483647
 http.connections.reuse=true
+http.connections.tokenhandler.enable=false
 http.connections.stale.check.ms=5000
 
 # Total number of connections in the pool

--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -236,7 +236,7 @@ http.compression.enable=true
 # Integer.MAX_VALUE
 http.connections.route=2147483647
 http.connections.reuse=true
-http.connections.tokenhandler.enable=false
+http.connections.state.enable=false
 http.connections.stale.check.ms=5000
 
 # Total number of connections in the pool

--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -249,6 +249,7 @@ http.socket.buffer=8192
 http.credentials.charset=UTF-8
 http.request.uri.normalize=false
 http.request.entity.buffer.limit=5242880
+request.unauthorized.ntlm.preflight=false
 
 # Enable or disable verification that the remote host taking part
 # of a data connection is the same as the host to which the control

--- a/nextcloud/src/main/java/ch/cyberduck/core/nextcloud/NextcloudWriteFeature.java
+++ b/nextcloud/src/main/java/ch/cyberduck/core/nextcloud/NextcloudWriteFeature.java
@@ -37,8 +37,8 @@ public class NextcloudWriteFeature extends DAVWriteFeature {
     }
 
     @Override
-    protected List<Header> getHeaders(final Path file, final TransferStatus status) throws UnsupportedException {
-        final List<Header> headers = super.getHeaders(file, status);
+    protected List<Header> toHeaders(final Path file, final TransferStatus status, final boolean expectdirective) throws UnsupportedException {
+        final List<Header> headers = super.toHeaders(file, status, expectdirective);
         if(null != status.getModified()) {
             headers.add(new BasicHeader("X-OC-Mtime", String.valueOf(status.getModified() / 1000)));
         }

--- a/webdav/src/main/java/ch/cyberduck/core/dav/DAVSession.java
+++ b/webdav/src/main/java/ch/cyberduck/core/dav/DAVSession.java
@@ -107,14 +107,7 @@ public class DAVSession extends HttpSession<DAVClient> {
     protected HttpClientBuilder getConfiguration(final Proxy proxy, final LoginCallback prompt) throws ConnectionCanceledException {
         final HttpClientBuilder configuration = builder.build(proxy, this, prompt);
         configuration.setRedirectStrategy(new DAVRedirectStrategy(redirect));
-        configuration.addInterceptorLast(new HttpResponseInterceptor() {
-            @Override
-            public void process(final HttpResponse response, final HttpContext context) {
-                if(response.containsHeader("Persistent-Auth")) {
-                    client.disablePreemptiveAuthentication();
-                }
-            }
-        });
+        configuration.addInterceptorLast(new MicrosoftIISPersistentAuthResponseInterceptor());
         return configuration;
     }
 
@@ -398,6 +391,15 @@ public class DAVSession extends HttpSession<DAVClient> {
         public HttpCapabilities withIIS(final boolean iis) {
             this.iis = iis;
             return this;
+        }
+    }
+
+    private final class MicrosoftIISPersistentAuthResponseInterceptor implements HttpResponseInterceptor {
+        @Override
+        public void process(final HttpResponse response, final HttpContext context) {
+            if(response.containsHeader("Persistent-Auth")) {
+                client.disablePreemptiveAuthentication();
+            }
         }
     }
 }

--- a/webdav/src/main/java/ch/cyberduck/core/dav/DAVUploadFeature.java
+++ b/webdav/src/main/java/ch/cyberduck/core/dav/DAVUploadFeature.java
@@ -17,6 +17,7 @@ package ch.cyberduck.core.dav;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import ch.cyberduck.core.features.Write;
 import ch.cyberduck.core.http.HttpUploadFeature;
 
 import java.security.MessageDigest;
@@ -25,5 +26,9 @@ public class DAVUploadFeature extends HttpUploadFeature<Void, MessageDigest> {
 
     public DAVUploadFeature(final DAVSession session) {
         super(new DAVWriteFeature(session));
+    }
+
+    public DAVUploadFeature(final Write<Void> writer) {
+        super(writer);
     }
 }

--- a/webdav/src/main/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISFeaturesResponseHandler.java
+++ b/webdav/src/main/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISFeaturesResponseHandler.java
@@ -1,0 +1,52 @@
+package ch.cyberduck.core.dav.microsoft;
+
+/*
+ * Copyright (c) 2002-2024 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.dav.DAVSession;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.github.sardine.impl.handler.ValidatingResponseHandler;
+
+public final class MicrosoftIISFeaturesResponseHandler extends ValidatingResponseHandler<Void> {
+    private static final Logger log = LogManager.getLogger(MicrosoftIISFeaturesResponseHandler.class);
+
+    private final DAVSession.HttpCapabilities capabilities;
+
+    public MicrosoftIISFeaturesResponseHandler(final DAVSession.HttpCapabilities capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    @Override
+    public Void handleResponse(final HttpResponse response) throws IOException {
+        if(Arrays.stream(response.getAllHeaders()).anyMatch(header ->
+                HttpHeaders.SERVER.equals(header.getName()) && StringUtils.contains(header.getValue(), "Microsoft-IIS"))) {
+            if(log.isInfoEnabled()) {
+                log.info(String.format("Microsoft-IIS backend detected in response %s", response));
+            }
+            capabilities.withIIS(true);
+        }
+        this.validateResponse(response);
+        return null;
+    }
+}

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/AbstractMicrosoftIISDAVTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/AbstractMicrosoftIISDAVTest.java
@@ -1,0 +1,83 @@
+package ch.cyberduck.core.dav.microsoft;
+
+/*
+ * Copyright (c) 2002-2018 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.Credentials;
+import ch.cyberduck.core.DisabledCancelCallback;
+import ch.cyberduck.core.DisabledHostKeyCallback;
+import ch.cyberduck.core.DisabledLoginCallback;
+import ch.cyberduck.core.DisabledPasswordStore;
+import ch.cyberduck.core.DisabledProgressListener;
+import ch.cyberduck.core.Host;
+import ch.cyberduck.core.LoginConnectionService;
+import ch.cyberduck.core.LoginOptions;
+import ch.cyberduck.core.Profile;
+import ch.cyberduck.core.ProtocolFactory;
+import ch.cyberduck.core.Scheme;
+import ch.cyberduck.core.dav.DAVProtocol;
+import ch.cyberduck.core.dav.DAVSession;
+import ch.cyberduck.core.serializer.impl.dd.ProfilePlistReader;
+import ch.cyberduck.core.ssl.DefaultX509KeyManager;
+import ch.cyberduck.core.ssl.DefaultX509TrustManager;
+import ch.cyberduck.test.VaultTest;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.Assert.fail;
+
+public class AbstractMicrosoftIISDAVTest extends VaultTest {
+
+    protected DAVSession session;
+
+    @After
+    public void disconnect() throws Exception {
+        session.close();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        final ProtocolFactory factory = new ProtocolFactory(new HashSet<>(Collections.singleton(new DAVProtocol())));
+        final Profile profile = new ProfilePlistReader(factory).read(
+                this.getClass().getResourceAsStream("/DAV.cyberduckprofile"));
+        session = new DAVSession(new Host(profile, "winbuild.iterate.ch", profile.getDefaultPort(), "/WebDAV", new Credentials(
+                PROPERTIES.get("webdav.iis.user"), PROPERTIES.get("webdav.iis.password")
+        )), new DefaultX509TrustManager(), new DefaultX509KeyManager());
+        final LoginConnectionService login = new LoginConnectionService(new DisabledLoginCallback() {
+            @Override
+            public Credentials prompt(final Host bookmark, final String title, final String reason, final LoginOptions options) {
+                fail(reason);
+                return null;
+            }
+
+            @Override
+            public void warn(final Host bookmark, final String title, final String message, final String continueButton, final String disconnectButton, final String preference) {
+                //
+            }
+        }, new DisabledHostKeyCallback(), new TestPasswordStore(), new DisabledProgressListener());
+        login.check(session, new DisabledCancelCallback());
+    }
+
+    public static class TestPasswordStore extends DisabledPasswordStore {
+        @Override
+        public String getPassword(Scheme scheme, int port, String hostname, String user) {
+            return PROPERTIES.get("webdav.iis.password");
+        }
+    }
+}

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVLockFeatureTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVLockFeatureTest.java
@@ -16,33 +16,23 @@ package ch.cyberduck.core.dav.microsoft;
  */
 
 import ch.cyberduck.core.AlphanumericRandomStringService;
-import ch.cyberduck.core.Credentials;
-import ch.cyberduck.core.DisabledCancelCallback;
 import ch.cyberduck.core.DisabledConnectionCallback;
-import ch.cyberduck.core.DisabledHostKeyCallback;
 import ch.cyberduck.core.DisabledListProgressListener;
 import ch.cyberduck.core.DisabledLoginCallback;
-import ch.cyberduck.core.Host;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Path;
 import ch.cyberduck.core.PathAttributes;
 import ch.cyberduck.core.dav.DAVDeleteFeature;
 import ch.cyberduck.core.dav.DAVLockFeature;
-import ch.cyberduck.core.dav.DAVProtocol;
-import ch.cyberduck.core.dav.DAVSession;
 import ch.cyberduck.core.dav.DAVUploadFeature;
 import ch.cyberduck.core.dav.DAVWriteFeature;
 import ch.cyberduck.core.features.Delete;
 import ch.cyberduck.core.http.HttpUploadFeature;
 import ch.cyberduck.core.io.BandwidthThrottle;
 import ch.cyberduck.core.io.DisabledStreamListener;
-import ch.cyberduck.core.proxy.Proxy;
 import ch.cyberduck.core.shared.DefaultHomeFinderService;
-import ch.cyberduck.core.ssl.DefaultX509KeyManager;
-import ch.cyberduck.core.ssl.DisabledX509TrustManager;
 import ch.cyberduck.core.transfer.TransferStatus;
 import ch.cyberduck.test.IntegrationTest;
-import ch.cyberduck.test.VaultTest;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -57,17 +47,10 @@ import java.util.EnumSet;
 import static org.junit.Assert.*;
 
 @Category(IntegrationTest.class)
-public class MicrosoftIISDAVLockFeatureTest extends VaultTest {
+public class MicrosoftIISDAVLockFeatureTest extends AbstractMicrosoftIISDAVTest {
 
     @Test
     public void testLock() throws Exception {
-        final Host host = new Host(new DAVProtocol(), "winbuild.iterate.ch", new Credentials(
-                PROPERTIES.get("webdav.iis.user"), PROPERTIES.get("webdav.iis.password")
-        ));
-        host.setDefaultPath("/WebDAV");
-        final DAVSession session = new DAVSession(host, new DisabledX509TrustManager(), new DefaultX509KeyManager());
-        session.open(Proxy.DIRECT, new DisabledHostKeyCallback(), new DisabledLoginCallback(), new DisabledCancelCallback());
-        session.login(Proxy.DIRECT, new DisabledLoginCallback(), new DisabledCancelCallback());
         final TransferStatus status = new TransferStatus();
         final Local local = new Local(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         final byte[] content = "test".getBytes(StandardCharsets.UTF_8);

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVLockFeatureTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVLockFeatureTest.java
@@ -83,5 +83,6 @@ public class MicrosoftIISDAVLockFeatureTest extends AbstractMicrosoftIISDAVTest 
         }
         new DAVLockFeature(session).unlock(test, lock);
         new DAVDeleteFeature(session).delete(Collections.singletonList(test), new DisabledLoginCallback(), new Delete.DisabledCallback());
+        local.delete();
     }
 }

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVReadFeatureTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVReadFeatureTest.java
@@ -16,29 +16,19 @@ package ch.cyberduck.core.dav.microsoft;
  */
 
 import ch.cyberduck.core.AlphanumericRandomStringService;
-import ch.cyberduck.core.Credentials;
-import ch.cyberduck.core.DisabledCancelCallback;
 import ch.cyberduck.core.DisabledConnectionCallback;
-import ch.cyberduck.core.DisabledHostKeyCallback;
 import ch.cyberduck.core.DisabledListProgressListener;
 import ch.cyberduck.core.DisabledLoginCallback;
-import ch.cyberduck.core.Host;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Path;
-import ch.cyberduck.core.dav.AbstractDAVTest;
 import ch.cyberduck.core.dav.DAVDeleteFeature;
-import ch.cyberduck.core.dav.DAVProtocol;
-import ch.cyberduck.core.dav.DAVSession;
 import ch.cyberduck.core.dav.DAVTouchFeature;
 import ch.cyberduck.core.dav.DAVUploadFeature;
 import ch.cyberduck.core.features.Delete;
 import ch.cyberduck.core.io.BandwidthThrottle;
 import ch.cyberduck.core.io.DisabledStreamListener;
 import ch.cyberduck.core.io.StreamCopier;
-import ch.cyberduck.core.proxy.Proxy;
 import ch.cyberduck.core.shared.DefaultHomeFinderService;
-import ch.cyberduck.core.ssl.DefaultX509KeyManager;
-import ch.cyberduck.core.ssl.DisabledX509TrustManager;
 import ch.cyberduck.core.transfer.TransferStatus;
 import ch.cyberduck.test.IntegrationTest;
 
@@ -56,17 +46,10 @@ import java.util.EnumSet;
 import static org.junit.Assert.*;
 
 @Category(IntegrationTest.class)
-public class MicrosoftIISDAVReadFeatureTest extends AbstractDAVTest {
+public class MicrosoftIISDAVReadFeatureTest extends AbstractMicrosoftIISDAVTest {
 
     @Test
     public void testReadMicrosoft() throws Exception {
-        final Host host = new Host(new DAVProtocol(), "winbuild.iterate.ch", new Credentials(
-                PROPERTIES.get("webdav.iis.user"), PROPERTIES.get("webdav.iis.password")
-        ));
-        host.setDefaultPath("/WebDAV");
-        final DAVSession session = new DAVSession(host, new DisabledX509TrustManager(), new DefaultX509KeyManager());
-        session.open(Proxy.DIRECT, new DisabledHostKeyCallback(), new DisabledLoginCallback(), new DisabledCancelCallback());
-        session.login(Proxy.DIRECT, new DisabledLoginCallback(), new DisabledCancelCallback());
         final Path test = new DAVTouchFeature(session).touch(new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file)), new TransferStatus());
         final Local local = new Local(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         final byte[] content = RandomUtils.nextBytes(1023);

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVTimestampFeatureTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVTimestampFeatureTest.java
@@ -16,25 +16,15 @@ package ch.cyberduck.core.dav.microsoft;
  */
 
 import ch.cyberduck.core.AlphanumericRandomStringService;
-import ch.cyberduck.core.Credentials;
 import ch.cyberduck.core.DefaultPathPredicate;
-import ch.cyberduck.core.DisabledCancelCallback;
-import ch.cyberduck.core.DisabledHostKeyCallback;
 import ch.cyberduck.core.DisabledListProgressListener;
 import ch.cyberduck.core.DisabledLoginCallback;
-import ch.cyberduck.core.Host;
 import ch.cyberduck.core.Path;
 import ch.cyberduck.core.PathAttributes;
-import ch.cyberduck.core.dav.AbstractDAVTest;
 import ch.cyberduck.core.dav.DAVDeleteFeature;
-import ch.cyberduck.core.dav.DAVProtocol;
-import ch.cyberduck.core.dav.DAVSession;
 import ch.cyberduck.core.dav.DAVTouchFeature;
 import ch.cyberduck.core.features.Delete;
-import ch.cyberduck.core.proxy.Proxy;
 import ch.cyberduck.core.shared.DefaultHomeFinderService;
-import ch.cyberduck.core.ssl.DefaultX509KeyManager;
-import ch.cyberduck.core.ssl.DisabledX509TrustManager;
 import ch.cyberduck.core.transfer.TransferStatus;
 import ch.cyberduck.test.IntegrationTest;
 
@@ -47,17 +37,10 @@ import java.util.EnumSet;
 import static org.junit.Assert.*;
 
 @Category(IntegrationTest.class)
-public class MicrosoftIISDAVTimestampFeatureTest extends AbstractDAVTest {
+public class MicrosoftIISDAVTimestampFeatureTest extends AbstractMicrosoftIISDAVTest {
 
     @Test
     public void testSetTimestamp() throws Exception {
-        final Host host = new Host(new DAVProtocol(), "winbuild.iterate.ch", new Credentials(
-                PROPERTIES.get("webdav.iis.user"), PROPERTIES.get("webdav.iis.password")
-        ));
-        host.setDefaultPath("/WebDAV");
-        final DAVSession session = new DAVSession(host, new DisabledX509TrustManager(), new DefaultX509KeyManager());
-        session.open(Proxy.DIRECT, new DisabledHostKeyCallback(), new DisabledLoginCallback(), new DisabledCancelCallback());
-        session.login(Proxy.DIRECT, new DisabledLoginCallback(), new DisabledCancelCallback());
         final Path file = new DAVTouchFeature(session).touch(new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file)), new TransferStatus());
         assertTrue(new MicrosoftIISDAVFindFeature(session).find(file));
         assertNotSame(PathAttributes.EMPTY, new MicrosoftIISDAVAttributesFinderFeature(session).find(file));

--- a/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVUploadFeatureTest.java
+++ b/webdav/src/test/java/ch/cyberduck/core/dav/microsoft/MicrosoftIISDAVUploadFeatureTest.java
@@ -1,0 +1,105 @@
+package ch.cyberduck.core.dav.microsoft;
+
+/*
+ * Copyright (c) 2002-2024 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.AlphanumericRandomStringService;
+import ch.cyberduck.core.DisabledConnectionCallback;
+import ch.cyberduck.core.DisabledLoginCallback;
+import ch.cyberduck.core.Local;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.dav.DAVDeleteFeature;
+import ch.cyberduck.core.dav.DAVUploadFeature;
+import ch.cyberduck.core.exception.InteroperabilityException;
+import ch.cyberduck.core.features.Delete;
+import ch.cyberduck.core.io.BandwidthThrottle;
+import ch.cyberduck.core.io.DisabledStreamListener;
+import ch.cyberduck.core.shared.DefaultHomeFinderService;
+import ch.cyberduck.core.transfer.TransferStatus;
+import ch.cyberduck.test.IntegrationTest;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.http.conn.ClientConnectionManager;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+@Category(IntegrationTest.class)
+public class MicrosoftIISDAVUploadFeatureTest extends AbstractMicrosoftIISDAVTest {
+
+    @Test
+    public void testUpload() throws Exception {
+        final Path test = new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file));
+        final Local local = new Local(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
+        final byte[] content = RandomUtils.nextBytes(9273);
+        final OutputStream out = local.getOutputStream(false);
+        assertNotNull(out);
+        IOUtils.write(content, out);
+        out.close();
+        new DAVUploadFeature(session).upload(
+                test, local, new BandwidthThrottle(BandwidthThrottle.UNLIMITED), new DisabledStreamListener(),
+                new TransferStatus().withLength(content.length),
+                new DisabledConnectionCallback());
+        new DAVDeleteFeature(session).delete(Collections.singletonList(test), new DisabledLoginCallback(), new Delete.DisabledCallback());
+        local.delete();
+    }
+
+    @Test
+    public void testUploadNoConnectionInPool() throws Exception {
+        final Path test = new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file));
+        final Local local = new Local(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
+        final byte[] content = RandomUtils.nextBytes(7365);
+        final OutputStream out = local.getOutputStream(false);
+        assertNotNull(out);
+        IOUtils.write(content, out);
+        out.close();
+        // Close connections in pool to require new NTLM handshake
+        final ClientConnectionManager manager = session.getClient().getClient().getConnectionManager();
+        manager.closeIdleConnections(0L, TimeUnit.MILLISECONDS);
+        assertThrows(InteroperabilityException.class, () -> new DAVUploadFeature(session).upload(
+                test, local, new BandwidthThrottle(BandwidthThrottle.UNLIMITED), new DisabledStreamListener(),
+                new TransferStatus().withLength(content.length),
+                new DisabledConnectionCallback()));
+        local.delete();
+    }
+
+    @Test
+    public void testZeroByteUploadNoConnectionInPool() throws Exception {
+        final Path test = new Path(new DefaultHomeFinderService(session).find(), new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file));
+        final Local local = new Local(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
+        final byte[] content = RandomUtils.nextBytes(0);
+        final OutputStream out = local.getOutputStream(false);
+        assertNotNull(out);
+        IOUtils.write(content, out);
+        out.close();
+        // Close connections in pool to require new NTLM handshake
+        final ClientConnectionManager manager = session.getClient().getClient().getConnectionManager();
+        manager.closeIdleConnections(0L, TimeUnit.MILLISECONDS);
+        new DAVUploadFeature(session).upload(
+                test, local, new BandwidthThrottle(BandwidthThrottle.UNLIMITED), new DisabledStreamListener(),
+                new TransferStatus().withLength(content.length),
+                new DisabledConnectionCallback());
+        new DAVDeleteFeature(session).delete(Collections.singletonList(test), new DisabledLoginCallback(), new Delete.DisabledCallback());
+        local.delete();
+    }
+}


### PR DESCRIPTION
Fix #15127. 

- [x] Ensure request context with authentication state is not shared between connections
- [ ] During the NTLM handshake HTTP requests must not contain a body but have `Content-Length: 0`. Otherwise Microsoft IIS will respond with `400 Bad Request` 
- [ ] When no connection is available from the pool for a `PUT` request we must ensure the entity is repeatable