### PR TITLE
`SHGetFileInfo(,,SHGFI_ICON,)` requires valid file extension to work

### DIFF
--- a/core/native/refresh/src/main/csharp/Services/IconProvider.cs
+++ b/core/native/refresh/src/main/csharp/Services/IconProvider.cs
@@ -119,7 +119,7 @@ namespace Ch.Cyberduck.Core.Refresh.Services
             else if (filename.LastIndexOf('.') is int index && index != -1)
             {
                 key = filename.Substring(index + 1);
-                fileInfo = key;
+                fileInfo = filename.Substring(index);
             }
 
             if (IconCache.TryGetIcon("ext", large ? 32 : 16, out T image, key))


### PR DESCRIPTION
Fixes #16053 
Regression from #15912 