### PR TITLE
Fix bugs in logging statement

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/profiles/ProfileDescription.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/ProfileDescription.java
@@ -82,7 +82,7 @@ public class ProfileDescription {
                     return new ProfilePlistReader(protocols, parent).read(local.get());
                 }
                 catch(AccessDeniedException e) {
-                    log.warn(String.format("Failure reading profile: %s", e));
+                    log.warn(String.format("Failure %s reading profile %s", e, local.get()));
                     throw new ConcurrentException(e);
                 }
             }

--- a/core/src/main/java/ch/cyberduck/core/profiles/ProfileDescription.java
+++ b/core/src/main/java/ch/cyberduck/core/profiles/ProfileDescription.java
@@ -82,7 +82,7 @@ public class ProfileDescription {
                     return new ProfilePlistReader(protocols, parent).read(local.get());
                 }
                 catch(AccessDeniedException e) {
-                    log.warn(String.format("Failure %s reading profile %s", e, e));
+                    log.warn(String.format("Failure reading profile: %s", e));
                     throw new ConcurrentException(e);
                 }
             }

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveAttributesFinderFeature.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveAttributesFinderFeature.java
@@ -96,7 +96,7 @@ public class DriveAttributesFinderFeature implements AttributesFinder, Attribute
                 return this.toAttributes(session.getClient().files().get(shortcutDetails.getTargetId()).setFields(DEFAULT_FIELDS).execute());
             }
             catch(IOException e) {
-                log.warn(String.format("Failure %s resolving shortcut for %s", e, e));
+                log.warn(String.format("Failure resolving shortcut for %s. Exception: %s", shortcutDetails.getTargetId(), e));
                 return PathAttributes.EMPTY;
             }
         }

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveAttributesFinderFeature.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveAttributesFinderFeature.java
@@ -96,7 +96,7 @@ public class DriveAttributesFinderFeature implements AttributesFinder, Attribute
                 return this.toAttributes(session.getClient().files().get(shortcutDetails.getTargetId()).setFields(DEFAULT_FIELDS).execute());
             }
             catch(IOException e) {
-                log.warn(String.format("Failure resolving shortcut for %s. Exception: %s", shortcutDetails.getTargetId(), e));
+                log.warn(String.format("Failure %s resolving shortcut for %s", e, f));
                 return PathAttributes.EMPTY;
             }
         }


### PR DESCRIPTION
## Description:
This pull request addresses an issue with the logging statement in the toAttributes method in the cyberduck_DriveAttributesFinderFeature_toAttributes.java file. The previous logging statement was not informative enough, as it logged the exception twice without providing context about the shortcut that was being resolved. This made it difficult to understand the nature of the failure from the logs.

## Reason for Changes:
The previous log message, `log.warn(String.format("Failure %s resolving shortcut for %s", e, e));`, was not helpful for debugging as it repeated the exception without clarifying the context.
The updated message, `log.warn(String.format("Failure resolving shortcut for %s. Exception: %s", shortcutDetails.getTargetId(), e));`, provides a clearer understanding of what went wrong, including details about the specific shortcut and the nature of the exception.

This change will make the logs more useful for developers and support staff when troubleshooting issues related to shortcut resolution in the application.


