### PR TITLE
Use home feature from derived implementations.

### DIFF
--- a/webdav/src/main/java/ch/cyberduck/core/dav/DAVSession.java
+++ b/webdav/src/main/java/ch/cyberduck/core/dav/DAVSession.java
@@ -163,7 +163,7 @@ public class DAVSession extends HttpSession<DAVClient> {
             return;
         }
         try {
-            final Path home = new DelegatingHomeFeature(new WorkdirHomeFeature(host), new DefaultPathHomeFeature(host)).find();
+            final Path home = this.getFeature(Home.class).find();
             final HttpHead head = new HttpHead(new DAVPathEncoder().encode(home));
             try {
                 client.execute(head, new MicrosoftIISFeaturesResponseHandler(capabilities));


### PR DESCRIPTION
Resolve interoperability with deployments that return `401` for `HEAD /`. Instead query `/remote.php/dav/`.