### PR TITLE
Refactor handling of security scoped bookmarks

### DIFF
--- a/core/dylib/src/main/java/ch/cyberduck/core/local/AbstractPromptBookmarkResolver.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/local/AbstractPromptBookmarkResolver.java
@@ -41,7 +41,7 @@ import org.rococoa.cocoa.foundation.NSInteger;
 import java.text.MessageFormat;
 import java.util.concurrent.atomic.AtomicReference;
 
-public abstract class AbstractPromptBookmarkResolver implements FilesystemBookmarkResolver<NSURL> {
+public abstract class AbstractPromptBookmarkResolver implements FilesystemBookmarkResolver<NSData, NSURL> {
     private static final Logger log = LogManager.getLogger(AbstractPromptBookmarkResolver.class);
 
     private final int create;
@@ -62,66 +62,46 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
     }
 
     @Override
-    public String create(final Local file) throws AccessDeniedException {
-        if(this.skip(file)) {
+    public NSData create(final Local file) throws AccessDeniedException {
+        if(skip(file)) {
             return null;
         }
-        final ObjCObjectByReference error = new ObjCObjectByReference();
         // Create new security scoped bookmark
         final NSURL url = NSURL.fileURLWithPath(file.getAbsolute());
         log.trace("Resolved file {} to url {}", file, url);
+        return this.create(url);
+    }
+
+    private NSData create(final NSURL url) throws LocalAccessDeniedException {
+        final ObjCObjectByReference error = new ObjCObjectByReference();
         final NSData data = url.bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error(
                 create, null, null, error);
         if(null == data) {
-            log.warn("Failure getting bookmark data for file {}", file);
+            log.warn("Failure getting bookmark data for file {}", url.path());
             final NSError f = error.getValueAs(NSError.class);
             if(null == f) {
-                throw new LocalAccessDeniedException(file.getAbsolute());
+                throw new LocalAccessDeniedException(url.path());
             }
             throw new LocalAccessDeniedException(String.format("%s", f.localizedDescription()));
         }
-        final String encoded = data.base64Encoding();
-        log.trace("Encoded bookmark for {} as {}", file, encoded);
-        return encoded;
+        log.trace("Created bookmark {} for {}", data.base64Encoding(), url.path());
+        return data;
     }
 
     @Override
-    public NSURL resolve(final Local file, final boolean interactive) throws AccessDeniedException {
-        if(this.skip(file)) {
+    public NSURL resolve(final NSData bookmark) throws AccessDeniedException {
+        if(null == bookmark) {
+            log.warn("Skip resolving null bookmark");
             return null;
-        }
-        final NSData bookmark;
-        if(null == file.getBookmark()) {
-            if(interactive) {
-                if(!file.exists()) {
-                    return null;
-                }
-                // Prompt user if no bookmark reference is available
-                log.warn("Missing security scoped bookmark for file {}", file);
-                final String reference = this.choose(file);
-                if(null == reference) {
-                    // Prompt canceled by user
-                    return null;
-                }
-                file.setBookmark(reference);
-                bookmark = NSData.dataWithBase64EncodedString(reference);
-            }
-            else {
-                log.warn("No security scoped bookmark for {}", file.getName());
-                return null;
-            }
-        }
-        else {
-            bookmark = NSData.dataWithBase64EncodedString(file.getBookmark());
         }
         final ObjCObjectByReference error = new ObjCObjectByReference();
         final NSURL resolved = NSURL.URLByResolvingBookmarkData(bookmark, resolve, error);
         if(null == resolved) {
-            log.warn("Error resolving bookmark for {} to URL", file);
             final NSError f = error.getValueAs(NSError.class);
             if(null == f) {
-                throw new LocalAccessDeniedException(file.getAbsolute());
+                throw new LocalAccessDeniedException();
             }
+            log.warn("Error {} resolving bookmark", f);
             throw new LocalAccessDeniedException(String.format("%s", f.localizedDescription()));
         }
         return resolved;
@@ -130,7 +110,7 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
     /**
      * Determine if creating security scoped bookmarks for file should be skipped
      */
-    private boolean skip(final Local file) {
+    private static boolean skip(final Local file) {
         if(null != TEMPORARY) {
             if(file.isChild(TEMPORARY)) {
                 // Skip prompt for file in temporary folder where access is not sandboxed
@@ -149,8 +129,13 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
     /**
      * @return Security scoped bookmark
      */
-    public String choose(final Local file) throws AccessDeniedException {
-        final AtomicReference<Local> selected = new AtomicReference<Local>();
+    @Override
+    public NSData prompt(final Local file) throws AccessDeniedException {
+        if(!file.exists()) {
+            log.warn("Skip prompting for non existing file {}", file);
+            return null;
+        }
+        final AtomicReference<NSURL> selected = new AtomicReference<>();
         log.warn("Prompt for file {} to obtain bookmark reference", file);
         final DefaultMainAction action = new DefaultMainAction() {
             @Override
@@ -160,7 +145,7 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
                 panel.setCanChooseFiles(file.isFile());
                 panel.setAllowsMultipleSelection(false);
                 panel.setMessage(MessageFormat.format(LocaleFactory.localizedString("Select {0}", "Credentials"),
-                    file.getAbbreviatedPath()));
+                        file.getAbbreviatedPath()));
                 panel.setPrompt(LocaleFactory.localizedString("Choose"));
                 final NSInteger modal = panel.runModal(file.getParent().getAbsolute(), file.getName());
                 if(modal.intValue() == SheetCallback.DEFAULT_OPTION) {
@@ -168,7 +153,7 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
                     final NSEnumerator enumerator = filenames.objectEnumerator();
                     NSObject next;
                     while((next = enumerator.nextObject()) != null) {
-                        selected.set(new FinderLocal(Rococoa.cast(next, NSURL.class).path()));
+                        selected.set(Rococoa.cast(next, NSURL.class));
                     }
                 }
                 panel.orderOut(null);
@@ -179,8 +164,6 @@ public abstract class AbstractPromptBookmarkResolver implements FilesystemBookma
             log.warn("Prompt for {} canceled", file);
             return null;
         }
-        // Save Base64 encoded scoped reference
         return this.create(selected.get());
     }
-
 }

--- a/core/dylib/src/main/java/ch/cyberduck/core/local/FilesystemBookmarkResolverFactory.java
+++ b/core/dylib/src/main/java/ch/cyberduck/core/local/FilesystemBookmarkResolverFactory.java
@@ -15,20 +15,15 @@ package ch.cyberduck.core.local;
  * GNU General Public License for more details.
  */
 
-import ch.cyberduck.binding.foundation.NSURL;
 import ch.cyberduck.core.Factory;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-public class FilesystemBookmarkResolverFactory extends Factory<FilesystemBookmarkResolver<NSURL>> {
-    private static final Logger log = LogManager.getLogger(FilesystemBookmarkResolverFactory.class);
+public class FilesystemBookmarkResolverFactory<Bookmark, Resolved> extends Factory<FilesystemBookmarkResolver<Bookmark, Resolved>> {
 
     private FilesystemBookmarkResolverFactory() {
         super("factory.bookmarkresolver.class");
     }
 
-    public static FilesystemBookmarkResolver<NSURL> get() {
-        return new FilesystemBookmarkResolverFactory().create();
+    public static <Bookmark, Resolved> FilesystemBookmarkResolver<Bookmark, Resolved> get() {
+        return new FilesystemBookmarkResolverFactory<Bookmark, Resolved>().create();
     }
 }

--- a/core/dylib/src/test/java/ch/cyberduck/core/local/AliasFilesystemBookmarkResolverTest.java
+++ b/core/dylib/src/test/java/ch/cyberduck/core/local/AliasFilesystemBookmarkResolverTest.java
@@ -15,6 +15,7 @@ package ch.cyberduck.core.local;
  * GNU General Public License for more details.
  */
 
+import ch.cyberduck.binding.foundation.NSData;
 import ch.cyberduck.binding.foundation.NSURL;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.exception.LocalAccessDeniedException;
@@ -47,9 +48,9 @@ public class AliasFilesystemBookmarkResolverTest {
         new DefaultLocalTouchFeature().touch(l);
         try {
             final AliasFilesystemBookmarkResolver resolver = new AliasFilesystemBookmarkResolver();
-            final String bookmark = resolver.create(l);
+            final NSData bookmark = resolver.create(l);
             assertNull(bookmark);
-            final NSURL resolved = resolver.resolve(l, false);
+            final NSURL resolved = resolver.resolve(bookmark);
             assertNull(resolved);
         }
         finally {
@@ -64,10 +65,9 @@ public class AliasFilesystemBookmarkResolverTest {
         new DefaultLocalTouchFeature().touch(l);
         try {
             final AliasFilesystemBookmarkResolver resolver = new AliasFilesystemBookmarkResolver();
-            final String bookmark = resolver.create(l);
+            final NSData bookmark = resolver.create(l);
             assertNotNull(bookmark);
-            l.setBookmark(bookmark);
-            final NSURL resolved = resolver.resolve(l, false);
+            final NSURL resolved = resolver.resolve(bookmark);
             assertNotNull(resolved);
         }
         finally {

--- a/core/dylib/src/test/java/ch/cyberduck/core/local/FinderLocalTest.java
+++ b/core/dylib/src/test/java/ch/cyberduck/core/local/FinderLocalTest.java
@@ -18,17 +18,20 @@ import ch.cyberduck.binding.foundation.NSURL;
 import ch.cyberduck.core.AlphanumericRandomStringService;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.Permission;
+import ch.cyberduck.core.SerializerFactory;
 import ch.cyberduck.core.exception.AccessDeniedException;
 import ch.cyberduck.core.exception.LocalAccessDeniedException;
 import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.serializer.LocalDictionary;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.dd.plist.NSDictionary;
 
 import static org.junit.Assert.*;
 
@@ -53,7 +56,7 @@ public class FinderLocalTest {
 
     @Test
     public void testEqual() throws Exception {
-        final String name = UUID.randomUUID().toString();
+        final String name = new AlphanumericRandomStringService().random();
         FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), name);
         assertEquals(new FinderLocal(System.getProperty("java.io.tmpdir"), name), l);
         new DefaultLocalTouchFeature().touch(l);
@@ -68,14 +71,14 @@ public class FinderLocalTest {
 
     @Test(expected = LocalAccessDeniedException.class)
     public void testReadNoFile() throws Exception {
-        final String name = UUID.randomUUID().toString();
+        final String name = new AlphanumericRandomStringService().random();
         FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), name);
         l.getInputStream();
     }
 
     @Test
     public void testNoCaseSensitive() throws Exception {
-        final String name = UUID.randomUUID().toString();
+        final String name = new AlphanumericRandomStringService().random();
         FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), name);
         new DefaultLocalTouchFeature().touch(l);
         assertTrue(l.exists());
@@ -91,7 +94,7 @@ public class FinderLocalTest {
 
     @Test(expected = LocalAccessDeniedException.class)
     public void testListNotFound() throws Exception {
-        final String name = UUID.randomUUID().toString();
+        final String name = new AlphanumericRandomStringService().random();
         FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), name);
         l.list();
     }
@@ -109,7 +112,7 @@ public class FinderLocalTest {
 
     @Test
     public void testWriteUnixPermission() throws Exception {
-        Local l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+        Local l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         new DefaultLocalTouchFeature().touch(l);
         final Permission permission = new Permission(644);
         l.attributes().setPermission(permission);
@@ -119,7 +122,7 @@ public class FinderLocalTest {
 
     @Test
     public void testMkdir() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         new DefaultLocalDirectoryFeature().mkdir(l);
         assertTrue(l.exists());
         new DefaultLocalDirectoryFeature().mkdir(l);
@@ -133,28 +136,21 @@ public class FinderLocalTest {
     }
 
     @Test
-    public void testBookmark() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("user.dir"), UUID.randomUUID().toString(), new AliasFilesystemBookmarkResolver());
-        assertNull(l.getBookmark());
-        new DefaultLocalTouchFeature().touch(l);
-        assertNotNull(l.getBookmark());
-        assertEquals(l.getBookmark(), l.getBookmark());
-        l.delete();
-    }
-
-    @Test
-    public void testBookmarkSaved() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+    public void testBookmarkSerialize() {
+        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         assertNull(l.getBookmark());
         l.setBookmark("a");
         assertEquals("a", l.getBookmark());
-        assertNotNull(l.getOutputStream(false));
-        assertNotNull(l.getInputStream());
+        final NSDictionary dict = l.serialize(SerializerFactory.get());
+        assertTrue(dict.containsKey("Bookmark"));
+        assertEquals("a", dict.objectForKey("Bookmark").toString());
+        final Local deserialized = new LocalDictionary<NSDictionary>().deserialize(dict);
+        assertEquals("a", deserialized.getBookmark());
     }
 
     @Test(expected = NotfoundException.class)
     public void testSymlinkTargetNotfound() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         try {
             assertNull(l.getSymlinkTarget());
         }
@@ -184,12 +180,12 @@ public class FinderLocalTest {
 
     @Test
     public void testSkipSecurityScopeBookmarkInTemporary() throws Exception {
-        final FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString(), new AliasFilesystemBookmarkResolver()) {
+        final FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random()) {
             @Override
             public NSURL lock(final boolean interactive) throws AccessDeniedException {
-                final NSURL lock = super.lock(interactive);
+                final NSURL lock = super.lock(interactive, new AliasFilesystemBookmarkResolver());
                 assertNull(lock);
-                return lock;
+                return null;
             }
         };
         new DefaultLocalTouchFeature().touch(l);
@@ -201,10 +197,10 @@ public class FinderLocalTest {
     @Test
     public void testReleaseSecurityScopeBookmarkInputStreamClose() throws Exception {
         final AtomicBoolean released = new AtomicBoolean(false);
-        final FinderLocal l = new FinderLocal(System.getProperty("user.dir"), UUID.randomUUID().toString(), new AliasFilesystemBookmarkResolver()) {
+        final FinderLocal l = new FinderLocal(System.getProperty("user.dir"), new AlphanumericRandomStringService().random()) {
             @Override
             public NSURL lock(final boolean interactive) throws AccessDeniedException {
-                final NSURL lock = super.lock(interactive);
+                final NSURL lock = super.lock(interactive, new AliasFilesystemBookmarkResolver());
                 assertNotNull(lock);
                 return lock;
             }
@@ -224,16 +220,16 @@ public class FinderLocalTest {
 
     @Test
     public void testLockNoSuchFile() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         assertNull(l.lock(false));
     }
 
     @Test
     public void testLockTemporary() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString(), new AliasFilesystemBookmarkResolver());
+        FinderLocal l = new FinderLocal(System.getProperty("java.io.tmpdir"), new AlphanumericRandomStringService().random());
         new DefaultLocalTouchFeature().touch(l);
         try {
-            final NSURL lock = l.lock(false);
+            final NSURL lock = l.lock(false, new AliasFilesystemBookmarkResolver());
             assertNull(lock);
             l.release(lock);
         }
@@ -244,10 +240,10 @@ public class FinderLocalTest {
 
     @Test
     public void testLockUserdir() throws Exception {
-        FinderLocal l = new FinderLocal(System.getProperty("user.dir"), UUID.randomUUID().toString(), new AliasFilesystemBookmarkResolver());
+        FinderLocal l = new FinderLocal(System.getProperty("user.dir"), new AlphanumericRandomStringService().random());
         new DefaultLocalTouchFeature().touch(l);
         try {
-            final NSURL lock = l.lock(false);
+            final NSURL lock = l.lock(false, new AliasFilesystemBookmarkResolver());
             assertNotNull(lock);
             l.release(lock);
         }
@@ -263,14 +259,14 @@ public class FinderLocalTest {
 
     @Test
     public void testIsSymbolicLink() {
-        assertFalse(new FinderLocal(UUID.randomUUID().toString()).isSymbolicLink());
+        assertFalse(new FinderLocal(new AlphanumericRandomStringService().random()).isSymbolicLink());
         assertTrue(new FinderLocal("/tmp").isSymbolicLink());
     }
 
     @Test
     public void testMoveFolder() throws Exception {
-        final String name = UUID.randomUUID().toString();
-        final String newname = UUID.randomUUID().toString();
+        final String name = new AlphanumericRandomStringService().random();
+        final String newname = new AlphanumericRandomStringService().random();
         new DefaultLocalDirectoryFeature().mkdir(new FinderLocal(name));
         new FinderLocal(name).rename(new FinderLocal(newname));
         assertFalse(new FinderLocal(name).exists());

--- a/core/dylib/src/test/java/ch/cyberduck/core/local/SecurityScopedFilesystemBookmarkResolverTest.java
+++ b/core/dylib/src/test/java/ch/cyberduck/core/local/SecurityScopedFilesystemBookmarkResolverTest.java
@@ -17,11 +17,11 @@ package ch.cyberduck.core.local;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import ch.cyberduck.binding.foundation.NSData;
 import ch.cyberduck.binding.foundation.NSURL;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.exception.LocalAccessDeniedException;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -44,17 +44,15 @@ public class SecurityScopedFilesystemBookmarkResolverTest {
     }
 
     @Test
-    @Ignore
-    public void testCreateFile() throws Exception {
+    public void testCreateFileUserdir() throws Exception {
         final String name = UUID.randomUUID().toString();
-        Local l = new FinderLocal(System.getProperty("java.io.tmpdir"), name);
+        Local l = new FinderLocal(System.getProperty("user.dir"), name);
         new DefaultLocalTouchFeature().touch(l);
         try {
             final SecurityScopedFilesystemBookmarkResolver resolver = new SecurityScopedFilesystemBookmarkResolver();
-            final String bookmark = resolver.create(l);
+            final NSData bookmark = resolver.create(l);
             assertNotNull(bookmark);
-            l.setBookmark(bookmark);
-            final NSURL resolved = resolver.resolve(l, false);
+            final NSURL resolved = resolver.resolve(bookmark);
             assertNotNull(resolved);
         }
         finally {

--- a/core/src/main/java/ch/cyberduck/core/Local.java
+++ b/core/src/main/java/ch/cyberduck/core/Local.java
@@ -68,6 +68,7 @@ public class Local extends AbstractPath implements Referenceable, Serializable {
      * Absolute path in local file system
      */
     private String path;
+    private String bookmark;
 
     public Local(final String parent, final String name) {
         this(parent, name, PreferencesFactory.get().getProperty("local.delimiter"));
@@ -114,7 +115,11 @@ public class Local extends AbstractPath implements Referenceable, Serializable {
 
     @Override
     public <T> T serialize(final Serializer<T> dict) {
-        dict.setStringForKey(path, "Path");
+        dict.setStringForKey(this.getAbbreviatedPath(), "Path");
+        final String bookmark = this.getBookmark();
+        if(bookmark != null) {
+            dict.setStringForKey(bookmark, "Bookmark");
+        }
         return dict.getSerialized();
     }
 
@@ -266,14 +271,17 @@ public class Local extends AbstractPath implements Referenceable, Serializable {
     }
 
     /**
-     * @return Security scoped bookmark outside of sandbox to store in preferences
+     * @return Application scoped bookmark to access outside of sandbox
      */
     public String getBookmark() {
-        return path;
+        return bookmark;
     }
 
+    /**
+     * @param data Security scoped bookmark to save for later retrieval of file reference or null to remove
+     */
     public void setBookmark(final String data) {
-        //
+        this.bookmark = data;
     }
 
     public Local withBookmark(final String data) {

--- a/core/src/main/java/ch/cyberduck/core/local/DisabledFilesystemBookmarkResolver.java
+++ b/core/src/main/java/ch/cyberduck/core/local/DisabledFilesystemBookmarkResolver.java
@@ -17,15 +17,15 @@ package ch.cyberduck.core.local;
 
 import ch.cyberduck.core.Local;
 
-public class DisabledFilesystemBookmarkResolver implements FilesystemBookmarkResolver<Void> {
+public class DisabledFilesystemBookmarkResolver implements FilesystemBookmarkResolver<Void, Void> {
 
     @Override
-    public String create(final Local file) {
+    public Void create(final Local file) {
         return null;
     }
 
     @Override
-    public Void resolve(final Local file, final boolean interactive) {
+    public Void resolve(final Void bookmark) {
         return null;
     }
 }

--- a/core/src/main/java/ch/cyberduck/core/local/FilesystemBookmarkResolver.java
+++ b/core/src/main/java/ch/cyberduck/core/local/FilesystemBookmarkResolver.java
@@ -21,7 +21,7 @@ package ch.cyberduck.core.local;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.exception.AccessDeniedException;
 
-public interface FilesystemBookmarkResolver<B> {
+public interface FilesystemBookmarkResolver<Bookmark, Resolved> {
 
     /**
      * Retain access to file-system resources with security-scoped bookmark.
@@ -30,15 +30,18 @@ public interface FilesystemBookmarkResolver<B> {
      * @return Security-scoped bookmark
      * @throws AccessDeniedException Failure resolving bookmark for file
      */
-    String create(Local file) throws AccessDeniedException;
+    Bookmark create(Local file) throws AccessDeniedException;
 
     /**
      * Resolve the security-scoped bookmark
      *
-     * @param file        File outside of sandbox
-     * @param interactive Allow prompt
+     * @param file File outside of sandbox
      * @return Reference to file by bookmark
      * @throws AccessDeniedException Failure resolving bookmark for file
      */
-    B resolve(Local file, final boolean interactive) throws AccessDeniedException;
+    Resolved resolve(Bookmark file) throws AccessDeniedException;
+
+    default Bookmark prompt(Local file) throws AccessDeniedException {
+        return null;
+    }
 }

--- a/core/src/test/java/ch/cyberduck/core/local/DisabledFilesystemBookmarkResolverTest.java
+++ b/core/src/test/java/ch/cyberduck/core/local/DisabledFilesystemBookmarkResolverTest.java
@@ -25,7 +25,7 @@ public class DisabledFilesystemBookmarkResolverTest {
 
     @Test
     public void testResolve() {
-        assertNull(new DisabledFilesystemBookmarkResolver().resolve(new NullLocal("/t"), false));
+        assertNull(new DisabledFilesystemBookmarkResolver().resolve(null));
     }
 
     @Test


### PR DESCRIPTION
Do not store bookmark data in user defaults causing performance issues.

```
2024-11-21 17:45:23.423301+0100 0xd2a399   Fault       0x319f83b            58342  0    Mountain Duck: (CoreFoundation) [com.apple.defaults:User Defaults] CFPrefsPlistSource<0x600003ca4600> (Domain: io.mountainduck, User: kCFPreferencesCurrentUser, ByHost: No, Container: (null), Contents Need Refresh: Yes): Attempting to store >= 4194304 bytes of data in CFPreferences/NSUserDefaults on this platform is invalid. This is a bug in Mountain Duck or a library it uses.
Description of keys being set:
b{43}9: string value, approximate encoded size: 2

Description of keys already present:
l{245}x: string value, approximate encoded size: 2464
l{217}e: string value, approximate encoded size: 2428
l{207}g: string value, approximate encoded size: 2416
l{206}e: string value, approximate encoded size: 2416
l{202}t: string value, approximate encoded size: 2412
l{203}t: string value, approximate encoded size: 2412
l{202}t: string value, approximate encoded size: 2408
l{217}s: string value, approximate encoded size: 2400
l{196}x: string value, approximate encoded size: 2400
l{194}s: string value, approximate encoded size: 2368
...
Total keys: 52379 - Average approximate value size: 1657 bytes
```