### PR TITLE
Use strict FTP multiline parsing

### DIFF
--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -258,7 +258,7 @@ ftp.datachannel.verify=false
 ftp.datachannel.epsv=false
 ftp.socket.buffer=0
 
-ftp.parser.multiline.strict=false
+ftp.parser.multiline.strict=true
 ftp.parser.reply.strict=false
 ftp.parser.mlsd.perm.enable=false
 


### PR DESCRIPTION
Fixes situations where FTP server replies with e.g.
```
250-
550
250
```

Fixes #15892.