### PR TITLE
Always scroll to recently added transfer

### DIFF
--- a/windows/src/main/csharp/ch/cyberduck/ui/ViewModels/TransfersViewModel.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/ViewModels/TransfersViewModel.cs
@@ -424,11 +424,7 @@ public sealed partial class TransfersViewModel : ObservableObject, IDisposable
 
     private void OnRevealTransfer(TransferViewModel transfer)
     {
-        if (SelectedTransfers.Count is 0)
-        {
-            SelectedTransfer = transfer;
-        }
-        
+        SelectedTransfer = transfer;
         WeakReferenceMessenger.Default.Send(new BringIntoViewMessage(transfer));
     }
 

--- a/windows/src/main/csharp/ch/cyberduck/ui/ViewModels/TransfersViewModel.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/ViewModels/TransfersViewModel.cs
@@ -427,8 +427,9 @@ public sealed partial class TransfersViewModel : ObservableObject, IDisposable
         if (SelectedTransfers.Count is 0)
         {
             SelectedTransfer = transfer;
-            WeakReferenceMessenger.Default.Send(new BringIntoViewMessage(transfer));
         }
+        
+        WeakReferenceMessenger.Default.Send(new BringIntoViewMessage(transfer));
     }
 
     private void OnSelectedBandwidthChanged(BandwidthViewModel value)


### PR DESCRIPTION
See #17251 
User intent is to start a transfer, this transfer should be brought into visible viewport.
Selection will only be performed when nothing has been selected prior.