### PR TITLE
GroupMember.Read.All permission required for Group Displayname

### DIFF
--- a/profiles/default/Microsoft SharePoint.cyberduckprofile
+++ b/profiles/default/Microsoft SharePoint.cyberduckprofile
@@ -44,6 +44,7 @@
             <string>sites.readwrite.all</string>
             <string>files.readwrite.all</string>
             <string>user.read</string>
+            <string>groupmember.read.all</string>
             <string>offline_access</string>
         </array>
         <key>OAuth Client ID</key>


### PR DESCRIPTION
Fixes #17304 