### PR TITLE
Refresh FileInfo after copying

### DIFF
--- a/core/src/main/csharp/ch/cyberduck/core/preferences/LocalSharedFileSettingsProvider.cs
+++ b/core/src/main/csharp/ch/cyberduck/core/preferences/LocalSharedFileSettingsProvider.cs
@@ -47,6 +47,10 @@ public class LocalSharedFileSettingsProvider : SettingsProvider
             {
                 Logger.error("Copying user.config", e);
             }
+            finally
+            {
+                userConfigFile.Refresh();
+            }
         }
 
         userConfig = userConfigFile;


### PR DESCRIPTION
Surprisingly, FileSystemInfo.Exists is cached.
Force Refresh after copying.

Addendum to #17268