### PR TITLE
Filter bogus Item in OneDrive listings

### DIFF
--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractListService.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractListService.java
@@ -22,6 +22,7 @@ import ch.cyberduck.core.Path;
 import ch.cyberduck.core.exception.BackgroundException;
 import ch.cyberduck.core.onedrive.features.GraphFileIdProvider;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.nuxeo.onedrive.client.OneDriveRuntimeException;
@@ -55,7 +56,12 @@ public abstract class AbstractListService<T> implements ListService {
                     log.debug("Filtering metadata {} in {}", metadata, directory);
                     continue;
                 }
-                children.add(toPath(metadata, directory));
+                final Path path = toPath(metadata, directory);
+                if (StringUtils.isBlank(path.attributes().getFileId())) {
+                    log.warn("Filtering inaccessible {} for {}", path, metadata);
+                    continue;
+                }
+                children.add(path);
             }
         }
         catch(OneDriveRuntimeException e) { // this catches iterator.hasNext in iterate()

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/OneDriveSession.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/OneDriveSession.java
@@ -67,9 +67,11 @@ public class OneDriveSession extends GraphSession {
                         remoteParent.getDriveId(), remoteMetadata.getId());
             }
         }
-        else {
+        else if(parent != null) {
             return String.join(String.valueOf(Path.DELIMITER), parent.getDriveId(), metadata.getId());
         }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
SharedWithMeListService can return empty ParentReference for an item
Filtering in base implementation for any empty file id.