### PR TITLE
Filter early on non-constructible path

### DIFF
--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractDriveListService.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractDriveListService.java
@@ -43,16 +43,15 @@ public abstract class AbstractDriveListService extends AbstractListService<Drive
                 attributes.setSize(used);
             }
         }
-        String name = metadata.getName();
-        if(StringUtils.isBlank(metadata.getName())) {
-            name = metadata.getId();
-        }
-        return new Path(directory, name, EnumSet.of(Path.Type.directory, Path.Type.volume), attributes);
+        return new Path(directory, metadata.getName(), EnumSet.of(Path.Type.directory, Path.Type.volume), attributes);
     }
 
     @Override
     protected boolean filter(final Path directory, final Metadata metadata) {
         if(StringUtils.isBlank(metadata.getId())) {
+            return false;
+        }
+        if(StringUtils.isBlank(metadata.getName())) {
             return false;
         }
         return super.filter(directory, metadata);

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractItemListService.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/AbstractItemListService.java
@@ -25,7 +25,6 @@ import ch.cyberduck.core.webloc.UrlFileWriterFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.nuxeo.onedrive.client.types.DriveItem;
-import org.nuxeo.onedrive.client.types.DriveItem.Metadata;
 
 import java.util.EnumSet;
 
@@ -53,8 +52,9 @@ public abstract class AbstractItemListService extends AbstractListService<DriveI
     }
 
     @Override
-    protected boolean filter(final Path directory, final Metadata metadata) {
-        if(StringUtils.isBlank(metadata.getId())) {
+    protected boolean filter(final Path directory, final DriveItem.Metadata metadata) {
+        // Don't filter on Id, as it is generated in toPath() from Session.
+        if(StringUtils.isBlank(metadata.getName())) {
             return false;
         }
         return super.filter(directory, metadata);

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/sharepoint/GroupListService.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/sharepoint/GroupListService.java
@@ -52,19 +52,15 @@ public class GroupListService extends AbstractListService<GroupItem.Metadata> {
     protected Path toPath(final GroupItem.Metadata metadata, final Path directory) {
         final PathAttributes attributes = new PathAttributes();
         attributes.setFileId(metadata.getId());
-        final String name;
-        if(StringUtils.isBlank(metadata.getDisplayName())) {
-            name = metadata.getId();
-        }
-        else {
-            name = metadata.getDisplayName();
-        }
-        return new Path(directory, name, EnumSet.of(Path.Type.volume, Path.Type.directory, Path.Type.placeholder), attributes);
+        return new Path(directory, metadata.getDisplayName(), EnumSet.of(Path.Type.volume, Path.Type.directory, Path.Type.placeholder), attributes);
     }
 
     @Override
     protected boolean filter(final Path directory, final GroupItem.Metadata metadata) {
         if(StringUtils.isBlank(metadata.getId())) {
+            return false;
+        }
+        if(StringUtils.isBlank(metadata.getDisplayName())) {
             return false;
         }
         return super.filter(directory, metadata);

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/sharepoint/SitesListService.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/sharepoint/SitesListService.java
@@ -63,6 +63,9 @@ public class SitesListService extends AbstractListService<Site.Metadata> {
         if(StringUtils.isBlank(metadata.getId())) {
             return false;
         }
+        if(StringUtils.isBlank(metadata.getName())) {
+            return false;
+        }
         if(!session.isSingleSite() && directory.getParent().isRoot()) {
             if(metadata.getRoot() == null) {
                 return false;


### PR DESCRIPTION
Filters all paths that cannot be created (empty Name) earlier (Path constructor throws on empty name).
Removes the Name to Id fallback logic, hiding bad answers completely.