### PR TITLE
Sanitize User-Agent HTTP header

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/PreferencesUseragentProvider.java
+++ b/core/src/main/java/ch/cyberduck/core/PreferencesUseragentProvider.java
@@ -40,20 +40,20 @@ public class PreferencesUseragentProvider implements UseragentProvider {
     }
 
     private static String sanitizeApplicationName(final String application) {
-        final char[] rfc2616TokenSeparators = new char[]{
-                '(', ')', '<', '>', '@',
-                ',', ';', ':', '\\', '"',
-                '/', '[', ']', '?', '=',
-                '{', '}', ' ', '\t'
+        final char[] httpHeaderTokenSeparators = new char[]{
+                ' ', '\t', '"', '(', ')',
+                ',', '/', ':', ';', '<',
+                '=', '>', '?', '@', '[',
+                '\\', ']', '{', '}'
         };
-        if(StringUtils.indexOfAny(application, rfc2616TokenSeparators) == -1) {
+        if(StringUtils.indexOfAny(application, httpHeaderTokenSeparators) == -1) {
             return application;
         }
 
         final StringBuilder builder = new StringBuilder(application.length() - 1);
         for(int i = 0; i < application.length(); i++) {
             final char token = application.charAt(i);
-            if(ArrayUtils.indexOf(rfc2616TokenSeparators, token) != -1) {
+            if(ArrayUtils.indexOf(httpHeaderTokenSeparators, token) != -1) {
                 continue;
             }
 

--- a/core/src/main/java/ch/cyberduck/core/PreferencesUseragentProvider.java
+++ b/core/src/main/java/ch/cyberduck/core/PreferencesUseragentProvider.java
@@ -49,17 +49,14 @@ public class PreferencesUseragentProvider implements UseragentProvider {
         if(StringUtils.indexOfAny(application, httpHeaderTokenSeparators) == -1) {
             return application;
         }
-
-        final StringBuilder builder = new StringBuilder(application.length() - 1);
+        final StringBuilder builder = new StringBuilder();
         for(int i = 0; i < application.length(); i++) {
             final char token = application.charAt(i);
             if(ArrayUtils.indexOf(httpHeaderTokenSeparators, token) != -1) {
                 continue;
             }
-
             builder.append(token);
         }
-
         return builder.toString();
     }
 


### PR DESCRIPTION
[RFC9110](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.2) requires the [User-Agent](https://www.rfc-editor.org/rfc/rfc9110#section-10.1.5) header to be well-formatted.
Currently, "Mountain Duck" violates this principle, as whitespace is not a valid token.