### PR TITLE
Fix race conditions in FTP socket closure that cause intermittent errors

### DIFF
--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPClient.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPClient.java
@@ -84,7 +84,8 @@ public class FTPClient extends FTPSClient {
         if(null == socket) {
             throw new FTPException(this.getReplyCode(), this.getReplyString());
         }
-        return socket;
+        // Wrap socket to ensure proper TCP shutdown sequence
+        return new FTPSocket(socket);
     }
 
     @Override

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
@@ -17,13 +17,11 @@ package ch.cyberduck.core.ftp;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
-import ch.cyberduck.core.preferences.PreferencesFactory;
-
+import org.apache.commons.io.input.ProxyInputStream;
+import org.apache.commons.io.output.ProxyOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -137,8 +135,7 @@ public class FTPSocket extends Socket {
     @Override
     public synchronized OutputStream getOutputStream() throws IOException {
         if(outputStreamWrapper == null) {
-            outputStreamWrapper = new BufferedOutputStream(delegate.getOutputStream(),
-                    PreferencesFactory.get().getInteger("connection.buffer")) {
+            outputStreamWrapper = new ProxyOutputStream(delegate.getOutputStream()) {
                 @Override
                 public void close() throws IOException {
                     try {
@@ -162,8 +159,7 @@ public class FTPSocket extends Socket {
     @Override
     public synchronized InputStream getInputStream() throws IOException {
         if(inputStreamWrapper == null) {
-            inputStreamWrapper = new BufferedInputStream(delegate.getInputStream(),
-                    PreferencesFactory.get().getInteger("connection.buffer")) {
+            inputStreamWrapper = new ProxyInputStream(delegate.getInputStream()) {
                 @Override
                 public void close() throws IOException {
                     // Stream close will call Socket.close(), so override it with ours

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
@@ -1,0 +1,293 @@
+package ch.cyberduck.core.ftp;
+
+/*
+ * Copyright (c) 2002-2025 David Kocher. All rights reserved.
+ * http://cyberduck.ch/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
+ */
+
+import ch.cyberduck.core.ConnectionTimeout;
+import ch.cyberduck.core.ConnectionTimeoutFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Socket wrapper that enforces proper TCP shutdown sequence to prevent
+ * race conditions due to premature socket closure during FTP data connections.
+ * <p>
+ * This fixes issues where:
+ * - macOS: Intermittent "426 Connection closed; transfer aborted" errors due to socket closure before server ACKs
+ * - Windows: Intermittent transfer hanging due to socket closure before client sends FIN with last data packet
+ * <p>
+ * The proper TCP shutdown sequence is:
+ * 1. Call shutdownOutput() to send FIN while keeping socket input open for ACKs
+ * 2. Drain input to wait for ACKs until we receive server FIN
+ * 3. Close the socket to release resources
+ */
+public class FTPSocket extends Socket {
+    private static final Logger log = LogManager.getLogger(FTPSocket.class);
+
+    private final Socket delegate;
+
+    private final ConnectionTimeout connectionTimeoutPreferences = ConnectionTimeoutFactory.get();
+
+    public FTPSocket(final Socket delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if(delegate.isClosed() || delegate.isOutputShutdown() || !delegate.isConnected()) {
+                log.debug("Socket already closed {}", delegate);
+            }
+            else {
+                // Shutdown output to send FIN, but keep socket open to receive ACKs
+                log.debug("Shutting down output for socket {}", delegate);
+                delegate.shutdownOutput();
+
+                // Wait for server FIN by draining any remaining data
+                // This ensures all our data packets are ACKed before closing
+                try {
+                    // Avoid hanging in case the server malfunctions
+                    delegate.setSoTimeout(connectionTimeoutPreferences.getTimeout() * 1000);
+                    InputStream in = delegate.getInputStream();
+                    byte[] buffer = new byte[8192];
+                    int bytesRead;
+                    // Read until EOF (server closes its side) or timeout
+                    while((bytesRead = in.read(buffer)) != -1) {
+                        log.debug("Drained {} bytes from socket after shutdown", bytesRead);
+                    }
+                    log.debug("Received EOF from server, all data acknowledged");
+                }
+                catch(java.net.SocketTimeoutException e) {
+                    // Timeout is acceptable - server may not close its side
+                    log.debug("Timeout waiting for server EOF, proceeding with close");
+                }
+                catch(IOException e) {
+                    // Other errors during drain are acceptable
+                    log.debug("Error draining socket: {}", e.getMessage());
+                }
+            }
+        }
+        catch(IOException e) {
+            log.warn("Failed to shutdown output for socket {}: {}", delegate, e.getMessage());
+        }
+        finally {
+            log.debug("Closing socket {}", delegate);
+            delegate.close();
+        }
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        delegate.connect(endpoint);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        delegate.connect(endpoint, timeout);
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        delegate.bind(bindpoint);
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return delegate.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return delegate.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return delegate.getChannel();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new FilterInputStream(delegate.getInputStream()) {
+            @Override
+            public void close() throws IOException {
+                FTPSocket.this.close(); // Call wrapper's close, not delegate's
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return new FilterOutputStream(delegate.getOutputStream()) {
+            @Override
+            public void close() throws IOException {
+                FTPSocket.this.close(); // Call wrapper's close, not delegate's
+            }
+        };
+    }
+
+    @Override
+    public void setTcpNoDelay(boolean on) throws SocketException {
+        delegate.setTcpNoDelay(on);
+    }
+
+    @Override
+    public boolean getTcpNoDelay() throws SocketException {
+        return delegate.getTcpNoDelay();
+    }
+
+    @Override
+    public void setSoLinger(boolean on, int linger) throws SocketException {
+        delegate.setSoLinger(on, linger);
+    }
+
+    @Override
+    public int getSoLinger() throws SocketException {
+        return delegate.getSoLinger();
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        delegate.sendUrgentData(data);
+    }
+
+    @Override
+    public void setOOBInline(boolean on) throws SocketException {
+        delegate.setOOBInline(on);
+    }
+
+    @Override
+    public boolean getOOBInline() throws SocketException {
+        return delegate.getOOBInline();
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) throws SocketException {
+        delegate.setSoTimeout(timeout);
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return delegate.getSoTimeout();
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        delegate.setSendBufferSize(size);
+    }
+
+    @Override
+    public int getSendBufferSize() throws SocketException {
+        return delegate.getSendBufferSize();
+    }
+
+    @Override
+    public void setReceiveBufferSize(int size) throws SocketException {
+        delegate.setReceiveBufferSize(size);
+    }
+
+    @Override
+    public int getReceiveBufferSize() throws SocketException {
+        return delegate.getReceiveBufferSize();
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        delegate.setKeepAlive(on);
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return delegate.getKeepAlive();
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        delegate.setTrafficClass(tc);
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        return delegate.getTrafficClass();
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        delegate.setReuseAddress(on);
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        return delegate.getReuseAddress();
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        delegate.shutdownInput();
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        delegate.shutdownOutput();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return delegate.isConnected();
+    }
+
+    @Override
+    public boolean isBound() {
+        return delegate.isBound();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return delegate.isInputShutdown();
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return delegate.isOutputShutdown();
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
+    }
+
+    @Override
+    public String toString() {
+        return "FTPSocket{" + delegate + "}";
+    }
+}

--- a/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
+++ b/ftp/src/main/java/ch/cyberduck/core/ftp/FTPSocket.java
@@ -17,8 +17,10 @@ package ch.cyberduck.core.ftp;
  * Bug fixes, suggestions and comments should be sent to feedback@cyberduck.ch
  */
 
+import com.amazonaws.internal.DelegateSocket;
+
 import org.apache.commons.io.input.ProxyInputStream;
-import org.apache.commons.io.output.ProxyOutputStream;
+import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,11 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.SocketAddress;
-import java.net.SocketException;
-import java.nio.channels.SocketChannel;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Socket wrapper that enforces proper TCP shutdown sequence to prevent
@@ -45,102 +43,69 @@ import java.util.concurrent.atomic.AtomicInteger;
  * 2. Drain input to wait for ACKs until we receive server FIN
  * 3. Close the socket to release resources
  */
-public class FTPSocket extends Socket {
+public class FTPSocket extends DelegateSocket {
     private static final Logger log = LogManager.getLogger(FTPSocket.class);
 
-    private final Socket delegate;
-    private final AtomicInteger outputBytesCount = new AtomicInteger(0);
-
     private InputStream inputStreamWrapper;
-    private OutputStream outputStreamWrapper;
+    private CountingOutputStream outputStreamWrapper;
 
-    public FTPSocket(final Socket delegate) {
-        this.delegate = delegate;
+    public FTPSocket(final Socket sock) {
+        super(sock);
     }
 
     @Override
     public synchronized void close() throws IOException {
-        if(delegate.isClosed()) {
-            log.debug("Socket already closed {}", delegate);
+        if(sock.isClosed()) {
+            log.debug("Socket already closed {}", sock);
             return;
         }
         try {
             // Only do full TCP shutdown if we have output bytes, otherwise close socket directly
-            if(outputBytesCount.get() > 0) {
-                if(delegate.isOutputShutdown()) {
-                    log.debug("Socket output already closed {}", delegate);
+            if(outputStreamWrapper != null && outputStreamWrapper.getByteCount() > 0) {
+                if(sock.isOutputShutdown()) {
+                    log.debug("Socket output already closed {}", sock);
                 }
-                else if(!delegate.isConnected()) {
-                    log.debug("Socket is already disconnected {}", delegate);
+                else if(!sock.isConnected()) {
+                    log.debug("Socket is already disconnected {}", sock);
                 }
                 else {
                     // Shutdown output to send FIN, but keep socket open to receive ACKs
-                    log.debug("Shutting down output for socket {}", delegate);
-                    delegate.shutdownOutput();
+                    log.debug("Shutting down output for socket {}", sock);
+                    sock.shutdownOutput();
 
-                    log.debug("Waiting for input to close for socket {}", delegate);
+                    log.debug("Waiting for input to close for socket {}", sock);
                     int bytesRead = 0;
                     // Read until EOF (server FIN) or timeout
-                    while(delegate.getInputStream().read() != -1) {
+                    while(sock.getInputStream().read() != -1) {
                         bytesRead++;
                     }
                     if(bytesRead > 0) {
-                        log.debug("Drained {} bytes from socket {}", bytesRead, delegate);
+                        log.warn("Drained {} bytes from socket {}", bytesRead, sock);
                     }
                 }
             }
         }
         finally {
-            log.debug("Closing socket {}", delegate);
+            log.debug("Closing socket {}", sock);
             // Work around macOS quirk where Java NIO's SocketDispatcher.close0() has a 1,000ms delay
             CompletableFuture.runAsync(() -> {
                 try {
-                    delegate.close();
+                    sock.close();
                 }
                 catch(IOException e) {
-                    log.error("Error closing socket {}: {}", delegate, e.getMessage());
+                    log.error("Error closing socket {}: {}", sock, e.getMessage());
                 }
             });
         }
     }
 
     @Override
-    public void connect(SocketAddress endpoint) throws IOException {
-        delegate.connect(endpoint);
-    }
-
-    @Override
-    public void connect(SocketAddress endpoint, int timeout) throws IOException {
-        delegate.connect(endpoint, timeout);
-    }
-
-    @Override
-    public void bind(SocketAddress bindpoint) throws IOException {
-        delegate.bind(bindpoint);
-    }
-
-    @Override
-    public SocketAddress getRemoteSocketAddress() {
-        return delegate.getRemoteSocketAddress();
-    }
-
-    @Override
-    public SocketAddress getLocalSocketAddress() {
-        return delegate.getLocalSocketAddress();
-    }
-
-    @Override
-    public SocketChannel getChannel() {
-        return delegate.getChannel();
-    }
-
-    @Override
     public synchronized OutputStream getOutputStream() throws IOException {
         if(outputStreamWrapper == null) {
-            outputStreamWrapper = new ProxyOutputStream(delegate.getOutputStream()) {
+            outputStreamWrapper = new CountingOutputStream(sock.getOutputStream()) {
                 @Override
                 public void close() throws IOException {
-                    // We can't call super.close() as it would call delegate.close()
+                    // We can't call super.close() as it would call sock.close()
                     // Therefore, we flush here and close the underlying stream ourselves
                     try {
                         super.flush();
@@ -148,11 +113,6 @@ public class FTPSocket extends Socket {
                     finally {
                         FTPSocket.this.close();
                     }
-                }
-
-                @Override
-                protected void afterWrite(final int n) {
-                    outputBytesCount.addAndGet(n);
                 }
             };
         }
@@ -162,154 +122,14 @@ public class FTPSocket extends Socket {
     @Override
     public synchronized InputStream getInputStream() throws IOException {
         if(inputStreamWrapper == null) {
-            inputStreamWrapper = new ProxyInputStream(delegate.getInputStream()) {
+            inputStreamWrapper = new ProxyInputStream(sock.getInputStream()) {
                 @Override
                 public void close() throws IOException {
-                    // super.close() will call delegate.close(), so override it with ours instead
+                    // super.close() will call sock.close(), so override it with ours instead
                     FTPSocket.this.close();
                 }
             };
         }
         return inputStreamWrapper;
-    }
-
-    @Override
-    public void setTcpNoDelay(boolean on) throws SocketException {
-        delegate.setTcpNoDelay(on);
-    }
-
-    @Override
-    public boolean getTcpNoDelay() throws SocketException {
-        return delegate.getTcpNoDelay();
-    }
-
-    @Override
-    public void setSoLinger(boolean on, int linger) throws SocketException {
-        delegate.setSoLinger(on, linger);
-    }
-
-    @Override
-    public int getSoLinger() throws SocketException {
-        return delegate.getSoLinger();
-    }
-
-    @Override
-    public void sendUrgentData(int data) throws IOException {
-        delegate.sendUrgentData(data);
-    }
-
-    @Override
-    public void setOOBInline(boolean on) throws SocketException {
-        delegate.setOOBInline(on);
-    }
-
-    @Override
-    public boolean getOOBInline() throws SocketException {
-        return delegate.getOOBInline();
-    }
-
-    @Override
-    public void setSoTimeout(int timeout) throws SocketException {
-        delegate.setSoTimeout(timeout);
-    }
-
-    @Override
-    public int getSoTimeout() throws SocketException {
-        return delegate.getSoTimeout();
-    }
-
-    @Override
-    public void setSendBufferSize(int size) throws SocketException {
-        delegate.setSendBufferSize(size);
-    }
-
-    @Override
-    public int getSendBufferSize() throws SocketException {
-        return delegate.getSendBufferSize();
-    }
-
-    @Override
-    public void setReceiveBufferSize(int size) throws SocketException {
-        delegate.setReceiveBufferSize(size);
-    }
-
-    @Override
-    public int getReceiveBufferSize() throws SocketException {
-        return delegate.getReceiveBufferSize();
-    }
-
-    @Override
-    public void setKeepAlive(boolean on) throws SocketException {
-        delegate.setKeepAlive(on);
-    }
-
-    @Override
-    public boolean getKeepAlive() throws SocketException {
-        return delegate.getKeepAlive();
-    }
-
-    @Override
-    public void setTrafficClass(int tc) throws SocketException {
-        delegate.setTrafficClass(tc);
-    }
-
-    @Override
-    public int getTrafficClass() throws SocketException {
-        return delegate.getTrafficClass();
-    }
-
-    @Override
-    public void setReuseAddress(boolean on) throws SocketException {
-        delegate.setReuseAddress(on);
-    }
-
-    @Override
-    public boolean getReuseAddress() throws SocketException {
-        return delegate.getReuseAddress();
-    }
-
-    @Override
-    public void shutdownInput() throws IOException {
-        delegate.shutdownInput();
-    }
-
-    @Override
-    public void shutdownOutput() throws IOException {
-        delegate.shutdownOutput();
-    }
-
-    @Override
-    public boolean isConnected() {
-        return delegate.isConnected();
-    }
-
-    @Override
-    public boolean isBound() {
-        return delegate.isBound();
-    }
-
-    @Override
-    public boolean isClosed() {
-        return delegate.isClosed();
-    }
-
-    @Override
-    public boolean isInputShutdown() {
-        return delegate.isInputShutdown();
-    }
-
-    @Override
-    public boolean isOutputShutdown() {
-        return delegate.isOutputShutdown();
-    }
-
-    @Override
-    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
-        delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
-    }
-
-    @Override
-    public String toString() {
-        return "FTPSocket{" + delegate + "}";
     }
 }


### PR DESCRIPTION
Hello!

First thing's first, I want to clarify that this issue was only experienced on macOS. I don't know if Windows is also affected.

Over the past years, I've been observing intermittent instances of `426 Connection closed; transfer aborted.` across various FTP servers (TLS and not). Recently, I tried to use Cyberduck to transfer files to my Nintendo Switch where I host a FTP server using [Sphaira](https://github.com/ITotalJustice/sphaira) or [FTPd](https://github.com/mtheall/ftpd). There I realized that the same intermittent issue now has more of a 50% chance to happen on every single file, rendering Cyberduck basically useless. I tried a variety of other clients and they never experienced such issues, so I just abandoned Cyberduck for this purpose.

However, today, I decided to dig into this properly. For some context, I am connecting over plain FTP, passive mode, over LAN. I noticed that the 426 occurs just at the end of a file transfer (e.g. 10GB file would transfer fine for minutes and then fails at 100%). I sniffed the packets with WireShark and noticed something interesting - Cyberduck was sometimes closing the socket right after the data is sent, before the server ACKs, resulting in RST. Here are dumps of a working and non-working case:

<details>
  <summary>TCP logs</summary>
  
  ```log
Failing:

1682	5.670201	192.168.1.125	192.168.1.224	FTP	161	Request: STOR TEST_FILE
1683	5.681870	192.168.1.224	192.168.1.125	FTP	77	Response: 150 Ready
1684	5.682013	192.168.1.125	192.168.1.224	TCP	66	50896 → 5000 [ACK] Seq=1386 Ack=1551 Win=131712 Len=0 TSval=3498841635 TSecr=1336843510
1685	5.683191	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1686	5.683194	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1687	5.683195	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1688	5.683196	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1689	5.683197	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1690	5.683197	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1691	5.683198	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1692	5.683199	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1693	5.683199	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1694	5.683200	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
1695	5.684527	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST, ACK] Seq=14481 Ack=1 Win=131776 Len=0
1696	5.687690	192.168.1.224	192.168.1.125	TCP	66	44429 → 50913 [ACK] Seq=1 Ack=2897 Win=62592 Len=0 TSval=2252654860 TSecr=2684224083
1697	5.687692	192.168.1.224	192.168.1.125	TCP	66	44429 → 50913 [ACK] Seq=1 Ack=5793 Win=59712 Len=0 TSval=2252654860 TSecr=2684224083
1698	5.687795	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST] Seq=2897 Win=0 Len=0
1699	5.687816	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST] Seq=5793 Win=0 Len=0
1700	5.688362	192.168.1.224	192.168.1.125	TCP	66	44429 → 50913 [ACK] Seq=1 Ack=8689 Win=64064 Len=0 TSval=2252654861 TSecr=2684224083
1701	5.688442	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST] Seq=8689 Win=0 Len=0
1702	5.688865	192.168.1.224	192.168.1.125	TCP	66	44429 → 50913 [ACK] Seq=1 Ack=11585 Win=61184 Len=0 TSval=2252654861 TSecr=2684224083
1703	5.688866	192.168.1.224	192.168.1.125	TCP	66	44429 → 50913 [ACK] Seq=1 Ack=14481 Win=58240 Len=0 TSval=2252654861 TSecr=2684224083
1704	5.688949	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST] Seq=11585 Win=0 Len=0
1705	5.689002	192.168.1.125	192.168.1.224	TCP	54	50913 → 44429 [RST] Seq=14481 Win=0 Len=0
1706	5.689473	192.168.1.224	192.168.1.125	FTP	94	Response: 426 Data connection failed
1707	5.689645	192.168.1.125	192.168.1.224	TCP	66	50896 → 5000 [ACK] Seq=1386 Ack=1579 Win=131712 Len=0 TSval=3498841642 TSecr=1336843516
1738	15.874697	192.168.1.224	192.168.1.125	TCP	66	5000 → 50836 [FIN, ACK] Seq=1 Ack=1 Win=16403 Len=0 TSval=1648215039 TSecr=3465173659
1739	15.874699	192.168.1.224	192.168.1.125	TCP	66	5000 → 50836 [RST, ACK] Seq=2 Ack=1 Win=16403 Len=0 TSval=1648215040 TSecr=3465173659
1740	15.874821	192.168.1.125	192.168.1.224	TCP	66	50836 → 5000 [ACK] Seq=1 Ack=2 Win=2058 Len=0 TSval=3465233565 TSecr=1648215039
1741	15.878489	192.168.1.224	192.168.1.125	TCP	54	5000 → 50836 [RST] Seq=2 Win=0 Len=0

Working:

218	4.607323	192.168.1.125	192.168.1.224	FTP	161	Request: STOR TEST_FILE
219	4.636985	192.168.1.224	192.168.1.125	FTP	77	Response: 150 Ready
220	4.637143	192.168.1.125	192.168.1.224	TCP	66	50976 → 5000 [ACK] Seq=390 Ack=843 Win=131712 Len=0 TSval=3644498421 TSecr=1805593578
221	4.638042	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
222	4.638045	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
223	4.638046	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
224	4.638047	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
225	4.638048	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
226	4.638049	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
227	4.638050	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
228	4.638051	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
229	4.638052	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
230	4.638053	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
232	4.642722	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=2897 Win=62592 Len=0 TSval=2609959962 TSecr=747574150
233	4.642724	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=5793 Win=59712 Len=0 TSval=2609959962 TSecr=747574150
234	4.642725	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=8689 Win=56832 Len=0 TSval=2609959962 TSecr=747574150
235	4.642837	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
236	4.642839	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
237	4.642839	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
238	4.642840	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
239	4.642890	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
240	4.642891	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
241	4.642891	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
242	4.642892	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
243	4.642921	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
244	4.642922	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
245	4.642922	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
246	4.642923	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
247	4.643444	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=11585 Win=62592 Len=0 TSval=2609959963 TSecr=747574150
249	4.643448	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=14481 Win=59712 Len=0 TSval=2609959963 TSecr=747574150
250	4.643541	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
251	4.643542	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
252	4.643543	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
253	4.643543	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
254	4.643576	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
255	4.643577	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
256	4.643577	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
257	4.643578	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
259	4.650031	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=17377 Win=62592 Len=0 TSval=2609959967 TSecr=747574156
260	4.650033	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=20273 Win=59712 Len=0 TSval=2609959967 TSecr=747574156
261	4.650034	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=23169 Win=56832 Len=0 TSval=2609959967 TSecr=747574156
262	4.650036	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=26065 Win=53952 Len=0 TSval=2609959967 TSecr=747574156
263	4.650037	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=28961 Win=51008 Len=0 TSval=2609959969 TSecr=747574156
264	4.650038	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=31857 Win=48128 Len=0 TSval=2609959969 TSecr=747574156
265	4.650039	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=34753 Win=45248 Len=0 TSval=2609959969 TSecr=747574156
266	4.650040	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=37649 Win=42368 Len=0 TSval=2609959969 TSecr=747574156
267	4.650041	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=40545 Win=39424 Len=0 TSval=2609959969 TSecr=747574156
268	4.650043	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=43441 Win=36544 Len=0 TSval=2609959969 TSecr=747574156
269	4.650044	192.168.1.224	192.168.1.125	TCP	66	[TCP Window Update] 32325 → 50984 [ACK] Seq=1 Ack=43441 Win=65536 Len=0 TSval=2609959969 TSecr=747574156
270	4.650193	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
271	4.650195	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
272	4.650196	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
273	4.650197	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
274	4.650233	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
275	4.650234	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
276	4.650235	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
277	4.650236	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
278	4.650249	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
279	4.650250	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
280	4.650251	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
281	4.650252	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
282	4.650267	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
283	4.650268	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
284	4.650269	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
285	4.650270	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
286	4.650287	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
287	4.650288	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
288	4.650289	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
289	4.650289	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
290	4.650306	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
291	4.650307	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
292	4.650307	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
293	4.650308	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
294	4.650318	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
295	4.650364	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
296	4.650365	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
297	4.650366	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
298	4.650366	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
299	4.650367	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
300	4.650367	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
301	4.650368	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
302	4.650368	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
303	4.650369	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
304	4.650369	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
305	4.650370	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
306	4.650371	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
307	4.650371	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
308	4.650372	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
309	4.650373	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
310	4.654428	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=46337 Win=62592 Len=0 TSval=2609959974 TSecr=747574163
311	4.654558	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
312	4.654561	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
313	4.654561	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
314	4.654562	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
315	4.657214	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=49233 Win=59712 Len=0 TSval=2609959974 TSecr=747574163
316	4.657216	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=52129 Win=56832 Len=0 TSval=2609959974 TSecr=747574163
317	4.657217	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=55025 Win=53952 Len=0 TSval=2609959974 TSecr=747574163
318	4.657364	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
319	4.659475	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=57921 Win=62592 Len=0 TSval=2609959975 TSecr=747574163
320	4.659476	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=60817 Win=59712 Len=0 TSval=2609959975 TSecr=747574163
321	4.659477	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=63713 Win=56832 Len=0 TSval=2609959975 TSecr=747574163
322	4.659478	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=66609 Win=53952 Len=0 TSval=2609959975 TSecr=747574163
323	4.659479	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=69505 Win=51008 Len=0 TSval=2609959976 TSecr=747574163
324	4.659480	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=72401 Win=48128 Len=0 TSval=2609959976 TSecr=747574163
325	4.659482	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=75297 Win=45248 Len=0 TSval=2609959977 TSecr=747574163
326	4.659483	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=78193 Win=42368 Len=0 TSval=2609959977 TSecr=747574163
327	4.659484	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=81089 Win=39424 Len=0 TSval=2609959977 TSecr=747574163
328	4.659485	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=83985 Win=36544 Len=0 TSval=2609959977 TSecr=747574163
329	4.659487	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=86881 Win=33664 Len=0 TSval=2609959977 TSecr=747574163
330	4.659488	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=89777 Win=30784 Len=0 TSval=2609959977 TSecr=747574163
331	4.659489	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=92673 Win=27840 Len=0 TSval=2609959977 TSecr=747574163
332	4.659490	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=95569 Win=24960 Len=0 TSval=2609959978 TSecr=747574163
333	4.659491	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=98465 Win=22080 Len=0 TSval=2609959978 TSecr=747574163
334	4.659492	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=101361 Win=19200 Len=0 TSval=2609959978 TSecr=747574163
335	4.659493	192.168.1.224	192.168.1.125	TCP	66	[TCP Window Update] 32325 → 50984 [ACK] Seq=1 Ack=101361 Win=65536 Len=0 TSval=2609959978 TSecr=747574163
336	4.659495	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=104257 Win=62592 Len=0 TSval=2609959979 TSecr=747574168
337	4.659496	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=107153 Win=59712 Len=0 TSval=2609959979 TSecr=747574168
338	4.659692	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
339	4.659695	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
340	4.659696	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
341	4.659697	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
342	4.659699	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
343	4.659700	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
344	4.659701	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
345	4.659702	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
346	4.659846	192.168.1.125	192.168.1.224	FTP-DATA	1514	FTP Data: 1448 bytes (PASV) (STOR TEST_FILE)
347	4.659887	192.168.1.125	192.168.1.224	FTP-DATA	449	FTP Data: 383 bytes (PASV) (STOR TEST_FILE)
348	4.665757	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=110049 Win=64064 Len=0 TSval=2609959984 TSecr=747574170
349	4.665759	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=112945 Win=61184 Len=0 TSval=2609959984 TSecr=747574173
350	4.665760	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=115841 Win=58240 Len=0 TSval=2609959984 TSecr=747574173
351	4.665762	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=118737 Win=55360 Len=0 TSval=2609959984 TSecr=747574173
352	4.665763	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=121633 Win=52480 Len=0 TSval=2609959985 TSecr=747574173
353	4.665764	192.168.1.224	192.168.1.125	TCP	66	32325 → 50984 [ACK] Seq=1 Ack=122017 Win=52096 Len=0 TSval=2609959985 TSecr=747574173
354	4.665766	192.168.1.224	192.168.1.125	FTP	74	Response: 226 OK
  ```

</details>

The fix in this PR definitely doesn't follow proper OOP - it's merely a PoC - but I think it gets the idea right. We half-close the socket (output only), signaling to the FTP server that we're done here. Then the server ACKs and responds with "226 OK", and only then we full-close the socket (input as well).

I re-ran my previously failing test cases a few hundred times, and all worked fine with this PR! The only caveat is, with this PR transfers to one of the FTP servers has a small delay between a file upload being complete, and a new file transfer starting. I compared with other FTP clients (Forklift on macOS) and there was no such delay. On the other FTP server, neither Cyberduck nor Forklift have this delay. 
