### PR TITLE
Restore fallback to read `SSH_AUTH_SOCK` 

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -285,7 +285,10 @@ public class SFTPSession extends Session<SSHClient> {
                     defaultMethods.add(new SFTPAgentAuthentication(client, new WindowsOpenSSHAgentAuthenticator()));
                     break;
             }
-            final String configuration = new OpenSSHIdentityAgentConfigurator().getIdentityAgent(host.getHostname());
+            String configuration = new OpenSSHIdentityAgentConfigurator().getIdentityAgent(host.getHostname());
+            if(null == configuration) {
+                configuration = System.getenv("SSH_AUTH_SOCK");
+            }
             if(configuration != null) {
                 final String identityAgent = LocalFactory.get(configuration).getAbsolute();
                 log.debug("Determined identity agent {} for {}", identityAgent, host.getHostname());


### PR DESCRIPTION
Restore fallback to read `SSH_AUTH_SOCK` from env with no explicit configuration for identity agent. Fix #17232.

Regresssion from d2bec0cc2033cbd5a4e06bf762e519b73c4444cc