### PR TITLE
add test demonstrating the HostParser issue

### DIFF
--- a/core/src/test/java/ch/cyberduck/core/HostParserTest.java
+++ b/core/src/test/java/ch/cyberduck/core/HostParserTest.java
@@ -40,6 +40,13 @@ public class HostParserTest {
     }
 
     @Test
+    public void parsePath() throws HostParserException {
+        final Host host = new HostParser(new ProtocolFactory(Collections.singleton(new TestProtocol(Scheme.https))))
+            .get("https://t%40u@host:443/key%2Fpart_a%2Fpart_b");
+        assertEquals("/key%2Fpart_a%2Fpart_b", host.getDefaultPath());
+    }
+
+    @Test
     public void parseNonConfigurableEmptyURL() throws HostParserException {
         final Host host = new HostParser(new ProtocolFactory(Collections.singleton(new TestProtocol(Scheme.https) {
             @Override


### PR DESCRIPTION
The problem here is that the path is resolved immediately:

https://host:443/key%2Fpart_a%2Fpart_b

becomes

https://host:443/key/part_a/part_b

and that is _not_ the same URL. And there is no way to actually reconstruct the initial URL as we don't know which slash stems from a '%2F' and which one was alway just a slash '/'. 

This PR is in response to: https://github.com/iterate-ch/cyberduck/pull/17613#issuecomment-3485570666

The HostParser is a very central component so I'm hesitant to even propose changing it!