### PR TITLE
Sign all unsigned dependencies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,6 +132,10 @@
             <classpath path="${lib.ext}/ant-dotnet-1.1.jar"/>
         </taskdef>
 
+        <condition property="msbuild.sign" value="false">
+            <isset property="skipSign"/>
+        </condition>
+        <property name="msbuild.sign" value="" />
         <condition property="msbuild.configuration" value="Debug">
             <equals arg1="${configuration}" arg2="debug"/>
         </condition>

--- a/cli/src/main/wix/Bundle/Cyberduck CLI-WiX.wxs
+++ b/cli/src/main/wix/Bundle/Cyberduck CLI-WiX.wxs
@@ -41,10 +41,10 @@
         <RegistryValue Root="HKLM" Key="Software\[Manufacturer]\[ProductName]" Name="InstallDir" Type="string" Value="[INSTALLLOCATION]" KeyPath="yes" />
       </Component>
       <Component Id="ProductExe" Guid="6D84843D-842B-4462-BF91-803D195AD0DB">
-        <File Id="product.exe" Source="$(var.CLI.TargetPath)" KeyPath="yes" Checksum="yes" />
+        <File Id="product.exe" Source="$(var.CLIPublishDir)duck.exe" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="ProductExe.Config" Guid="CFC37A9B-0CD5-439B-BFB5-A3176D6500A1">
-        <File Source="$(var.CLI.TargetPath).config" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)duck.exe.config" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="license" Guid="DF374856-F6F7-4520-A332-803CB0826593">
         <File Source="$(var.LicenseFile)" KeyPath="yes" Checksum="yes" />
@@ -53,72 +53,72 @@
         <File Source="$(var.CyberduckDir)Acknowledgments.rtf" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Cli" Guid="811AEB4A-4751-428E-9116-9F7396C5C2C8">
-        <File Source="$(var.CLI.TargetDir)/Cyberduck.Cli.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)Cyberduck.Cli.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="Cyberduck.Core" Guid="058A9F4C-D8E9-43C3-83C1-E0E7439ACD93">
-        <File Source="$(var.CLI.TargetDir)/Cyberduck.Core.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)Cyberduck.Core.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="Cyberduck.Protocols" Guid="A27F0196-0678-4AE6-9BD6-3EFD6EB1507A">
-        <File Source="$(var.CLI.TargetDir)/Cyberduck.Protocols.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)Cyberduck.Protocols.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="Cyberduck.Cryptomator" Guid="06296D3F-6A87-4E56-A346-53C7B5368E39">
-        <File Source="$(var.CLI.TargetDir)/Cyberduck.Cryptomator.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)Cyberduck.Cryptomator.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="Cyberduck.Core.Native" Guid="678E99DD-6943-495D-8742-ECE21846365D">
-        <File Source="$(var.CLI.TargetDir)/Cyberduck.Core.Native.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)Cyberduck.Core.Native.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <!-- IKVM -->
       <Component Id="IKVM.ByteCode.dll">
-        <File Source="$(var.CLI.TargetDir)/IKVM.ByteCode.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)IKVM.ByteCode.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.CoreLib.dll">
-        <File Source="$(var.CLI.TargetDir)/IKVM.CoreLib.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)IKVM.CoreLib.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="ikvm.dll">
-        <File Source="$(var.CLI.TargetDir)/ikvm.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)ikvm.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Java.dll">
-        <File Source="$(var.CLI.TargetDir)/IKVM.Java.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)IKVM.Java.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="ikvm.properties">
-        <File Source="$(var.CLI.TargetDir)/ikvm.properties" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)ikvm.properties" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Runtime.dll">
-        <File Source="$(var.CLI.TargetDir)/IKVM.Runtime.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)IKVM.Runtime.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Reflection.dll">
-        <File Source="$(var.CLI.TargetDir)/IKVM.Reflection.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)IKVM.Reflection.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="jnidispatch" Guid="B6621775-1A9A-461E-83B8-BB1EE34B5965">
-        <File Source="$(var.CLI.TargetDir)/jnidispatch.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)jnidispatch.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="vcruntime140">
-        <File Source="$(var.CLI.TargetDir)/vcruntime140.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)vcruntime140.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Id="vcruntime140_1">
-        <File Source="$(var.CLI.TargetDir)/vcruntime140_1.dll" KeyPath="yes" Checksum="yes"/>
+        <File Source="$(var.CLIPublishDir)vcruntime140_1.dll" KeyPath="yes" Checksum="yes"/>
       </Component>
 
       <Component Id="System.Buffers">
-        <File Source="$(var.CLI.TargetDir)/System.Buffers.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Buffers.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Memory">
-        <File Source="$(var.CLI.TargetDir)/System.Memory.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Memory.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Numerics.Vectors">
-        <File Source="$(var.CLI.TargetDir)/System.Numerics.Vectors.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Numerics.Vectors.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Runtime.CompilerServices.Unsafe">
-        <File Source="$(var.CLI.TargetDir)/System.Runtime.CompilerServices.Unsafe.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Runtime.CompilerServices.Unsafe.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Text.Json">
-        <File Source="$(var.CLI.TargetDir)/System.Text.Json.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Text.Json.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Collections.Immutable">
-        <File Source="$(var.CLI.TargetDir)/System.Collections.Immutable.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Collections.Immutable.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Reflection.Metadata">
-        <File Source="$(var.CLI.TargetDir)/System.Reflection.Metadata.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CLIPublishDir)System.Reflection.Metadata.dll" KeyPath="yes" Checksum="yes" />
       </Component>
     </ComponentGroup>
 

--- a/cli/src/main/wix/Bundle/duck.bundle.wixproj
+++ b/cli/src/main/wix/Bundle/duck.bundle.wixproj
@@ -12,7 +12,6 @@
       CyberduckDir=$(CyberduckDir);
       ProfilesDir=$(CyberduckDir)profiles\default\;
       LicenseFile=$(CyberduckDir)i18n/src/main/resources/en.lproj/License.txt;
-      IkvmRuntimeDir=$(TargetBuildDir)\ikvm;
       $(DefineConstants)
     </DefineConstants>
   </PropertyGroup>
@@ -28,17 +27,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <WixExtension Include="WixNetFxExtension">
+      <HintPath>$(WixExtDir)\WixNetFxExtension.dll</HintPath>
+      <Name>WixNetFxExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+
+  <ItemGroup>
     <HarvestDirectory Include="$(CyberduckDir)profiles\default" SuppressRootDirectory="true" SuppressCom="true" SuppressRegistry="true">
       <Link>Profiles</Link>
       <DirectoryRefId>PROFILES</DirectoryRefId>
       <ComponentGroupName>ProfileComponents</ComponentGroupName>
       <PreprocessorVariable>var.ProfilesDir</PreprocessorVariable>
-    </HarvestDirectory>
-    <HarvestDirectory Include="$(TargetBuildDir)ikvm" SuppressCom="true" SuppressRegistry="true">
-      <Link>ikvm</Link>
-      <DirectoryRefId>INSTALLLOCATION</DirectoryRefId>
-      <ComponentGroupName>IkvmRuntime</ComponentGroupName>
-      <PreprocessorVariable>var.IkvmRuntimeDir</PreprocessorVariable>
     </HarvestDirectory>
   </ItemGroup>
 
@@ -54,21 +54,31 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
 
+  <PropertyGroup>
+    <CLIPublishDir>$(IntermediateOutputPath)CLI\</CLIPublishDir>
+    <DefineConstants>
+      CLIPublishDir=$(CLIPublishDir);
+      IkvmRuntimeDir=$(CLIPublishDir)\ikvm;
+      $(DefineConstants)
+    </DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\csharp\duck.csproj">
       <Name>CLI</Name>
       <Project>{4b14000d-f435-4eca-a119-7aef03792dee}</Project>
+      <Targets>Publish</Targets>
       <Private>True</Private>
       <DoNotHarvest>True</DoNotHarvest>
       <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
       <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+      <AdditionalProperties>PublishDir=$(CLIPublishDir);RuntimeIdentifier=win-x64</AdditionalProperties>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <WixExtension Include="WixNetFxExtension">
-      <HintPath>$(WixExtDir)\WixNetFxExtension.dll</HintPath>
-      <Name>WixNetFxExtension</Name>
-    </WixExtension>
+    <HarvestDirectory Include="$(CLIPublishDir)ikvm" SuppressCom="true" SuppressRegistry="true">
+      <Link>ikvm</Link>
+      <DirectoryRefId>INSTALLLOCATION</DirectoryRefId>
+      <ComponentGroupName>IkvmRuntime</ComponentGroupName>
+      <PreprocessorVariable>var.IkvmRuntimeDir</PreprocessorVariable>
+    </HarvestDirectory>
   </ItemGroup>
 
   <Target Name="SignMsi" DependsOnTargets="SignToolArgs">
@@ -78,24 +88,25 @@
 	To modify your build process, add your task inside one of the targets below and uncomment it.
 	Other similar extension points exist, see Wix.targets.
   -->
-  <Target Name="_CollectPayload" Returns="@(SignPayload)">
+  <Target Name="BundlePayloadExecutable" Returns="@(BundlePayloadExecutable)">
     <ItemGroup>
-      <SignPayload Include="$(TargetBuildDir)*.dll;$(TargetBuildDir)*.exe" />
+      <BundlePayloadExecutable Include="$(CLIPublishDir)**\*.dll;$(CLIPublishDir)**\*.exe" />
     </ItemGroup>
   </Target>
-  <Target Name="CollectSignPayload" DependsOnTargets="_CollectPayload;SignToolArgs" Outputs="%(SignPayload.Identity)" Returns="@(SignPayload)">
-    <Exec Command="%22$(SignToolExecutable)%22 verify /q /pa %22%(SignPayload.Identity)%22"
-          EnvironmentVariables="@(SignToolEnvironmentVariable)"
-          IgnoreStandardErrorWarningFormat="true"
-          IgnoreExitCode="true">
+  <Target Name="CollectSignPayload" DependsOnTargets="BundlePayloadExecutable;SignToolArgs" Outputs="%(BundlePayloadExecutable.Identity)" Returns="@(SignBundlePayload)">
+    <Exec Command="%22$(SignToolExecutable)%22 verify /q /pa %22%(BundlePayloadExecutable.Identity)%22"
+      EnvironmentVariables="@(SignToolEnvironmentVariable)"
+      IgnoreStandardErrorWarningFormat="true"
+      IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="PayloadSigned" />
     </Exec>
 
     <ItemGroup>
-      <SignPayload Remove="%(SignPayload.Identity)" Condition="'$(PayloadSigned)'=='0'" />
+      <SignBundlePayload Include="@(BundlePayloadExecutable)" Condition="'$(PayloadSigned)'!='0'" />
     </ItemGroup>
   </Target>
+
   <Target Name="SignPayload" Condition=" '$(SignOutput)' == 'true' " DependsOnTargets="CollectSignPayload;SignToolArgs" AfterTargets="Compile" BeforeTargets="Link">
-    <Exec Command="$(SignToolArgs) @(SignPayload->'%22%(Identity)%22', ' ')" EnvironmentVariables="@(SignToolEnvironmentVariable)" Condition="'@(SignPayload)'!=''" />
+    <Exec Command="$(SignToolArgs) @(SignBundlePayload->'%22%(Identity)%22', ' ')" EnvironmentVariables="@(SignToolEnvironmentVariable)" Condition="'@(SignBundlePayload)'!=''" />
   </Target>
 </Project>

--- a/cli/windows/build.xml
+++ b/cli/windows/build.xml
@@ -41,18 +41,12 @@
     </target>
 
     <target name="package" depends="restore,msbuild">
-        <condition property="msbuild.sign" value="false">
-            <istrue value="${skip}"/>
-        </condition>
-        <property name="msbuild.sign" value=""/>
-
         <msbuild buildfile="build.proj">
             <target name="Build"/>
 
             <property name="BuildProjectReferences" value="false"/>
             <property name="Configuration" value="${msbuild.configuration}"/>
             <property name="Installer" value="true" />
-            <property name="SignOutput" value="${msbuild.sign}" />
         </msbuild>
     </target>
 

--- a/src/template/msbuild/Version.props
+++ b/src/template/msbuild/Version.props
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <SignOutput>${msbuild.sign}</SignOutput>
     <SignTool>${signtool}</SignTool>
     <SignToolCSP>${signtool.csp}</SignToolCSP>
     <SignToolKC>${signtool.kc}</SignToolKC>

--- a/windows/build.xml
+++ b/windows/build.xml
@@ -59,11 +59,6 @@
             </fileset>
         </copy>
 
-        <condition property="msbuild.sign" value="false">
-            <istrue value="${skip}" />
-        </condition>
-        <property name="msbuild.sign" value="" />
-
         <copy todir="${build}/generated" overwrite="True" encoding="UTF-8" outputencoding="UTF-8">
             <fileset dir="${module}/src/main/package">
                 <include name="**/*.template"/>
@@ -79,7 +74,6 @@
 
             <property name="BuildModule" value="Installer" />
             <property name="Configuration" value="${msbuild.configuration}" />
-            <property name="SignOutput" value="${msbuild.sign}" />
         </msbuild>
     </target>
 

--- a/windows/src/main/csharp/Cyberduck.csproj
+++ b/windows/src/main/csharp/Cyberduck.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" />
     <PackageReference Include="ExceptionReporter" />
     <PackageReference Include="IKVM">
-      <PrivateAssets>all</PrivateAssets>
+      <PrivateAssets>build;buildMultitargeting;buildTransitive</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
     <PackageReference Include="Microsoft.Windows.CsWin32">

--- a/windows/src/main/package/package.wapproj
+++ b/windows/src/main/package/package.wapproj
@@ -34,7 +34,7 @@
         <SignOutput Condition="'$(SignOutput)'==''">True</SignOutput>
     </PropertyGroup>
     <PropertyGroup>
-        <AppxPackageSigningEnabled>$(SignOutput)</AppxPackageSigningEnabled>
+        <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     </PropertyGroup>
     <ItemGroup>
         <None Include="Package.appxmanifest.template" />
@@ -68,4 +68,41 @@
     <ItemGroup>
         <ProjectReference Include="..\csharp\Cyberduck.csproj" />
     </ItemGroup>
+
+    <Target Name="ResolveLocalPackagePayload" BeforeTargets="_GenerateAppxPackageRecipeFile" Returns="@(AppxPackagePayload)">
+        <ItemGroup>
+            <_AppxPackagePayloadCopy Include="@(AppxPackagePayload)" Condition="Exists('$(TargetDir)%(TargetPath)')" />
+            <AppxPackagePayload Remove="@(_AppxPackagePayloadCopy)" />
+            <AppxPackagePayload Include="@(_AppxPackagePayloadCopy->'$(TargetDir)%(TargetPath)')" />
+        </ItemGroup>
+    </Target>
+    <Target Name="AppxPackagePayloadExecutable" DependsOnTargets="ResolveLocalPackagePayload" Returns="@(AppxPackagePayloadExecutable)">
+        <ItemGroup>
+            <AppxPackagePayloadExecutable Include="@(AppxPackagePayload)" Condition="'%(Extension)'=='.dll' Or '%(Extension)'=='.exe'" />
+        </ItemGroup>
+    </Target>
+    <Target Name="SignToolExecutablePath" DependsOnTargets="_GetSdkToolPaths" Returns="$(SignToolExecutablePath)">
+        <PropertyGroup>
+            <SignToolExecutable>$(SignAppxPackageExeFullPath)</SignToolExecutable>
+        </PropertyGroup>
+    </Target>
+    <Target Name="_CollectSignAppxPackagePayload" DependsOnTargets="AppxPackagePayloadExecutable;SignToolExecutablePath" Outputs="%(AppxPackagePayloadExecutable.Identity)">
+        <Exec Command="%22$(SignToolExecutable)%22 verify /q /pa %22%(AppxPackagePayloadExecutable.Identity)%22"
+            IgnoreStandardErrorWarningFormat="true"
+            IgnoreExitCode="true">
+            <Output TaskParameter="ExitCode" PropertyName="PayloadSigned" />
+        </Exec>
+
+        <ItemGroup>
+            <SignAppxPackagePayload Include="@(AppxPackagePayloadExecutable)" Condition="'$(PayloadSigned)'!='0'" />
+        </ItemGroup>
+    </Target>
+    <Target Name="SignAppxPackagePayload"
+        BeforeTargets="_GenerateAppxPackageFile"
+        DependsOnTargets="_CollectSignAppxPackagePayload;SignToolArgs"
+        Condition="'$(SignOutput)'=='true'">
+        <Exec Command="$(SignToolArgs) @(SignAppxPackagePayload->'%22%(TargetPath)%22', ' ')" 
+            WorkingDirectory="$(TargetDir)"
+            Condition="'@(SignAppxPackagePayload)'!=''" />
+    </Target>
 </Project>

--- a/windows/src/main/wix/Bundle/Cyberduck.Bundle.wixproj
+++ b/windows/src/main/wix/Bundle/Cyberduck.Bundle.wixproj
@@ -12,7 +12,6 @@
       CyberduckDir=$(CyberduckDir);
       ProfilesDir=$(CyberduckDir)profiles\default\;
       LicenseFile=$(CyberduckDir)i18n/src/main/resources/en.lproj/License.txt;
-      IkvmRuntimeDir=$(TargetBuildDir)\ikvm;
       $(DefineConstants)
     </DefineConstants>
   </PropertyGroup>
@@ -27,14 +26,6 @@
     <Compile Include="Cyberduck.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\csharp\Cyberduck.csproj">
-      <Name>cyberduck</Name>
-      <Project>{04AFCFBB-97D5-44EA-B087-F0CFAEB51E30}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
-      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
-    </ProjectReference>
     <ProjectReference Include="..\WindowsVersionCustomAction\WindowsVersionCustomAction.vcxproj">
       <Name>WindowsVersionCustomAction</Name>
       <Project>{fba5efe2-362b-4bad-a748-3248f79468ac}</Project>
@@ -62,12 +53,6 @@
       <ComponentGroupName>ProfileComponents</ComponentGroupName>
       <PreprocessorVariable>var.ProfilesDir</PreprocessorVariable>
     </HarvestDirectory>
-    <HarvestDirectory Include="$(TargetBuildDir)ikvm" SuppressCom="true" SuppressRegistry="true">
-      <Link>ikvm</Link>
-      <DirectoryRefId>INSTALLLOCATION</DirectoryRefId>
-      <ComponentGroupName>IkvmRuntime</ComponentGroupName>
-      <PreprocessorVariable>var.IkvmRuntimeDir</PreprocessorVariable>
-    </HarvestDirectory>
   </ItemGroup>
 
   <PropertyGroup>
@@ -82,6 +67,33 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
 
+  <PropertyGroup>
+    <CyberduckPublishDir>$(IntermediateOutputPath)Cyberduck\</CyberduckPublishDir>
+    <DefineConstants>
+      CyberduckPublishDir=$(CyberduckPublishDir);
+      IkvmRuntimeDir=$(CyberduckPublishDir)\ikvm;
+      $(DefineConstants)
+    </DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\csharp\Cyberduck.csproj">
+      <Name>cyberduck</Name>
+      <Project>{04AFCFBB-97D5-44EA-B087-F0CFAEB51E30}</Project>
+      <Targets>Publish</Targets>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+      <AdditionalProperties>PublishDir=$(CyberduckPublishDir);RuntimeIdentifier=win-x64</AdditionalProperties>
+    </ProjectReference>
+    <HarvestDirectory Include="$(CyberduckPublishDir)ikvm" SuppressCom="true" SuppressRegistry="true">
+      <Link>ikvm</Link>
+      <DirectoryRefId>INSTALLLOCATION</DirectoryRefId>
+      <ComponentGroupName>IkvmRuntime</ComponentGroupName>
+      <PreprocessorVariable>var.IkvmRuntimeDir</PreprocessorVariable>
+    </HarvestDirectory>
+  </ItemGroup>
+
   <Target Name="SignMsi" DependsOnTargets="SignToolArgs">
     <Exec Command="$(SignToolArgs) &quot;%(SignMsi.FullPath)&quot;" EnvironmentVariables="@(SignToolEnvironmentVariable)" />
   </Target>
@@ -89,24 +101,25 @@
 	To modify your build process, add your task inside one of the targets below and uncomment it.
 	Other similar extension points exist, see Wix.targets.
   -->
-  <Target Name="_CollectPayload" Returns="@(SignPayload)">
+  <Target Name="BundlePayloadExecutable" Returns="@(BundlePayloadExecutable)">
     <ItemGroup>
-      <SignPayload Include="$(TargetBuildDir)*.dll;$(TargetBuildDir)*.exe" />
+      <BundlePayloadExecutable Include="$(CyberduckPublishDir)**\*.dll;$(CyberduckPublishDir)**\*.exe" />
     </ItemGroup>
   </Target>
-  <Target Name="CollectSignPayload" DependsOnTargets="_CollectPayload;SignToolArgs" Outputs="%(SignPayload.Identity)" Returns="@(SignPayload)">
-    <Exec Command="%22$(SignToolExecutable)%22 verify /q /pa %22%(SignPayload.Identity)%22"
-          EnvironmentVariables="@(SignToolEnvironmentVariable)"
-          IgnoreStandardErrorWarningFormat="true"
-          IgnoreExitCode="true">
+  <Target Name="CollectSignPayload" DependsOnTargets="BundlePayloadExecutable;SignToolArgs" Outputs="%(BundlePayloadExecutable.Identity)" Returns="@(SignBundlePayload)">
+    <Exec Command="%22$(SignToolExecutable)%22 verify /q /pa %22%(BundlePayloadExecutable.Identity)%22"
+      EnvironmentVariables="@(SignToolEnvironmentVariable)"
+      IgnoreStandardErrorWarningFormat="true"
+      IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="PayloadSigned" />
     </Exec>
 
     <ItemGroup>
-      <SignPayload Remove="%(SignPayload.Identity)" Condition="'$(PayloadSigned)'=='0'" />
+      <SignBundlePayload Include="@(BundlePayloadExecutable)" Condition="'$(PayloadSigned)'!='0'" />
     </ItemGroup>
   </Target>
+
   <Target Name="SignPayload" Condition=" '$(SignOutput)' == 'true' " DependsOnTargets="CollectSignPayload;SignToolArgs" AfterTargets="Compile" BeforeTargets="Link">
-    <Exec Command="$(SignToolArgs) @(SignPayload->'%22%(Identity)%22', ' ')" EnvironmentVariables="@(SignToolEnvironmentVariable)" Condition="'@(SignPayload)'!=''" />
+    <Exec Command="$(SignToolArgs) @(SignBundlePayload->'%22%(Identity)%22', ' ')" EnvironmentVariables="@(SignToolEnvironmentVariable)" Condition="'@(SignBundlePayload)'!=''" />
   </Target>
 </Project>

--- a/windows/src/main/wix/Bundle/Cyberduck.wxs
+++ b/windows/src/main/wix/Bundle/Cyberduck.wxs
@@ -25,8 +25,8 @@
       </Directory>
     </Directory>
 
-    <Icon Id="icon.ico" SourceFile="$(var.cyberduck.TargetDir)/cyberduck-application.ico" />
-    <Icon Id="cd_document.ico" SourceFile="$(var.cyberduck.TargetDir)/cyberduck-document.ico" />
+    <Icon Id="icon.ico" SourceFile="$(var.CyberduckDir)cyberduck-application.ico" />
+    <Icon Id="cd_document.ico" SourceFile="$(var.CyberduckDir)cyberduck-document.ico" />
     <Property Id="ARPPRODUCTICON" Value="icon.ico" />
     <Property Id="AUTOSTART" Value="0" />
     <Property Id="REINSTALLMODE" Value="dmus" />
@@ -37,7 +37,7 @@
       </Component>
 
       <Component Id="ProductExe">
-        <File Id="product.exe" Source="$(var.cyberduck.TargetPath)" KeyPath="yes" Checksum="yes">
+        <File Id="product.exe" Source="$(var.CyberduckPublishDir)Cyberduck.exe" KeyPath="yes" Checksum="yes">
           <Shortcut Id="ApplicationStartMenuShortcut"
             Name="Cyberduck"
             Advertise="yes"
@@ -93,151 +93,151 @@
         <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Cyberduck.License" Name="FriendlyTypeName" Value="Cyberduck License" Type="string" />
       </Component>
       <Component Id="Cyberduck.Exe.Config">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.exe.config" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.exe.config" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="CustomOpenFileFolderDialog">
-        <File Source="$(var.cyberduck.TargetDir)/CustomOpenFileFolderDialog.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)CustomOpenFileFolderDialog.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Core">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Core.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Core.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Core.Native">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Core.Native.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Core.Native.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Core.Refresh">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Core.Refresh.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Core.Refresh.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Protocols">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Protocols.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Protocols.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Bonjour">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Bonjour.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Bonjour.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Bonjour.Native">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Bonjour.Native.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Bonjour.Native.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Importer">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Importer.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Importer.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Cyberduck.Cryptomator">
-        <File Source="$(var.cyberduck.TargetDir)/Cyberduck.Cryptomator.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Cyberduck.Cryptomator.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="WinSparkle">
-        <File Source="$(var.cyberduck.TargetDir)/WinSparkle.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)WinSparkle.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="objectlistview">
-        <File Source="$(var.cyberduck.TargetDir)/ObjectListView.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ObjectListView.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="jnidispatch">
-        <File Source="$(var.cyberduck.TargetDir)/jnidispatch.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)jnidispatch.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="vcruntime140">
-        <File Source="$(var.cyberduck.TargetDir)/vcruntime140.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)vcruntime140.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="vcruntime140_1">
-        <File Source="$(var.cyberduck.TargetDir)/vcruntime140_1.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)vcruntime140_1.dll" KeyPath="yes" Checksum="yes" />
       </Component>
 
       <!-- IKVM -->
       <Component Id="IKVM.ByteCode.dll">
-        <File Source="$(var.cyberduck.TargetDir)/IKVM.ByteCode.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)IKVM.ByteCode.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.CoreLib.dll">
-        <File Source="$(var.cyberduck.TargetDir)/IKVM.CoreLib.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)IKVM.CoreLib.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="ikvm.dll">
-        <File Source="$(var.cyberduck.TargetDir)/ikvm.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ikvm.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Java.dll">
-        <File Source="$(var.cyberduck.TargetDir)/IKVM.Java.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)IKVM.Java.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="ikvm.properties">
-        <File Source="$(var.cyberduck.TargetDir)/ikvm.properties" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ikvm.properties" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Runtime.dll">
-        <File Source="$(var.cyberduck.TargetDir)/IKVM.Runtime.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)IKVM.Runtime.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="IKVM.Reflection.dll">
-        <File Source="$(var.cyberduck.TargetDir)/IKVM.Reflection.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)IKVM.Reflection.dll" KeyPath="yes" Checksum="yes" />
       </Component>
 
       <Component Id="System.Buffers">
-        <File Source="$(var.cyberduck.TargetDir)/System.Buffers.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Buffers.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Memory">
-        <File Source="$(var.cyberduck.TargetDir)/System.Memory.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Memory.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Numerics.Vectors">
-        <File Source="$(var.cyberduck.TargetDir)/System.Numerics.Vectors.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Numerics.Vectors.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Runtime.CompilerServices.Unsafe">
-        <File Source="$(var.cyberduck.TargetDir)/System.Runtime.CompilerServices.Unsafe.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Runtime.CompilerServices.Unsafe.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Threading.Tasks.Extensions">
-        <File Source="$(var.cyberduck.TargetDir)/System.Threading.Tasks.Extensions.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Threading.Tasks.Extensions.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.ValueTuple">
-        <File Source="$(var.cyberduck.TargetDir)/System.ValueTuple.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.ValueTuple.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Text.Json">
-        <File Source="$(var.cyberduck.TargetDir)/System.Text.Json.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Text.Json.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Collections.Immutable">
-        <File Source="$(var.cyberduck.TargetDir)/System.Collections.Immutable.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Collections.Immutable.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="System.Reflection.Metadata">
-        <File Source="$(var.cyberduck.TargetDir)/System.Reflection.Metadata.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Reflection.Metadata.dll" KeyPath="yes" Checksum="yes" />
       </Component>
 
       <!-- NuGet Dependencies -->
       <!-- DotNetProjects.Extended.Wpf.Toolkit -->
       <Component Id="DotNetProjects.Wpf.Extended.Toolkit.dll">
-        <File Source="$(var.cyberduck.TargetDir)/DotNetProjects.Wpf.Extended.Toolkit.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)DotNetProjects.Wpf.Extended.Toolkit.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- ExceptionReporter -->
       <Component Id="ExceptionReporter.WinForms">
-        <File Source="$(var.cyberduck.TargetDir)/ExceptionReporter.NET.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ExceptionReporter.NET.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="DotNetZip">
-        <File Source="$(var.cyberduck.TargetDir)/DotNetZip.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)DotNetZip.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="SimpleMapi">
-        <File Source="$(var.cyberduck.TargetDir)/SimpleMapi.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)SimpleMapi.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- Microsoft.Toolkit.Uwp.Notifications -->
       <Component Id="MSTKUWPNotifications">
-        <File Source="$(var.cyberduck.TargetDir)/Microsoft.Toolkit.Uwp.Notifications.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Microsoft.Toolkit.Uwp.Notifications.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- System.Reactive -->
       <Component Id="System.Reactive">
-        <File Source="$(var.cyberduck.TargetDir)/System.Reactive.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)System.Reactive.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- ReactiveUI.WPF-->
       <Component Id="ReactiveUI.Wpf">
-        <File Source="$(var.cyberduck.TargetDir)/ReactiveUI.Wpf.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ReactiveUI.Wpf.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- ReactiveUI -->
       <Component Id="ReactiveUI">
-        <File Source="$(var.cyberduck.TargetDir)/ReactiveUI.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)ReactiveUI.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- DynamicData -->
       <Component Id="DynamicData">
-        <File Source="$(var.cyberduck.TargetDir)/DynamicData.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)DynamicData.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- Splat -->
       <Component Id="Splat">
-        <File Source="$(var.cyberduck.TargetDir)/Splat.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Splat.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- StructureMap -->
       <Component Id="structuremap">
-        <File Source="$(var.cyberduck.TargetDir)/StructureMap.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)StructureMap.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- CommunityToolkit.Mvvm -->
       <Component Id="CommunityToolkit.Mvvm">
-        <File Source="$(var.cyberduck.TargetDir)/CommunityToolkit.Mvvm.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)CommunityToolkit.Mvvm.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="Microsoft.Bcl.AsyncInterfaces">
-        <File Source="$(var.cyberduck.TargetDir)/Microsoft.Bcl.AsyncInterfaces.dll" KeyPath="yes" Checksum="yes" />
+        <File Source="$(var.CyberduckPublishDir)Microsoft.Bcl.AsyncInterfaces.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <!-- /Nuget Dependencies -->
 


### PR DESCRIPTION
Mimick Wix v4/v5 model of publishing any application to obj\ first, then copying from there.

Also rewrite paths from NuGet in wapproj to local output folder, so we can sign them without modifying the NuGet cache.

Addresses #17692 