### PR TITLE
Include context path in S3 presigned URLs

### DIFF
--- a/s3/src/main/java/ch/cyberduck/core/s3/S3PresignedUrlProvider.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3PresignedUrlProvider.java
@@ -20,9 +20,12 @@ package ch.cyberduck.core.s3;
 
 import ch.cyberduck.core.Credentials;
 import ch.cyberduck.core.Host;
+import ch.cyberduck.core.PathNormalizer;
+import ch.cyberduck.core.Scheme;
 import ch.cyberduck.core.preferences.HostPreferences;
 import ch.cyberduck.core.preferences.HostPreferencesFactory;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,6 +69,15 @@ public class S3PresignedUrlProvider {
                     return String.format(endpoint, region);
                 }
                 return bookmark.getHostname();
+            }
+
+            @Override
+            protected String getVirtualPath() {
+                final String context = bookmark.getProtocol().getContext();
+                if(StringUtils.isNotBlank(context) && !Scheme.isURL(context)) {
+                    return PathNormalizer.normalize(context);
+                }
+                return StringUtils.EMPTY;
             }
 
             @Override


### PR DESCRIPTION
Fixes #17831

## Summary

- Include the protocol context path (e.g., `/storage/v1/s3` for Supabase) in presigned URLs
- Override `getVirtualPath()` in the anonymous `RestS3Service` instance used for URL signing
- This mirrors the existing behavior in `RequestEntityRestStorageService` for regular S3 requests

## Problem

When using Cyberduck with the official Supabase Storage S3 profile (which sets `Context=/storage/v1/s3`), "Copy URL → Signed URL" generates a presigned URL that omits the context path prefix. The generated URL points to `https://<host>/<bucket>/<key>` instead of `https://<host>/storage/v1/s3/<bucket>/<key>`, causing Supabase to return `{"error":"requested path is invalid"}`.

## Solution

The fix adds a `getVirtualPath()` override in `S3PresignedUrlProvider` that returns the context path from the protocol configuration. This ensures the context path is included in both:
1. The URL path of the presigned URL
2. The canonical request used for SigV4 signature calculation

## Backward Compatibility

This change is backward compatible:
- For standard S3 providers (AWS, Wasabi, MinIO, etc.) where `getContext()` returns empty/null, `getVirtualPath()` returns an empty string — behavior unchanged
- Only profiles with an explicit `Context` setting (like Supabase) are affected

## Test plan

- [x] Added unit test `testContextPath()` verifying presigned URLs include the context path when configured