### PR TITLE
Add support for AWS credential_process configuration, allowing external processes to provide temporary AWS credentials.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.778</version>
+                <version>1.12.797</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
@@ -128,7 +128,7 @@ public class S3CredentialsConfigurator implements CredentialsConfigurator {
                     }
                 }
                 catch(IOException e) {
-                    log.warn("Failure \"{}\" parsing cached credentials from {}", e.getMessage(), command);
+                    log.warn("Failure \"{}\" parsing credentials from output of command {}", e.getMessage(), command);
                     return credentials;
                 }
             }

--- a/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
@@ -17,6 +17,7 @@ package ch.cyberduck.core.s3;
 
 import ch.cyberduck.core.Credentials;
 import ch.cyberduck.core.CredentialsConfigurator;
+import ch.cyberduck.core.Factory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.Local;
 import ch.cyberduck.core.LocalFactory;
@@ -33,8 +34,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -94,6 +97,40 @@ public class S3CredentialsConfigurator implements CredentialsConfigurator {
             return false;
         }).map(Map.Entry::getValue).findFirst().orElse(StringUtils.isBlank(host.getCredentials().getUsername()) ? profiles.get("default") : null);
         if(null != profile) {
+            if(profile.isProcessBasedProfile()) {
+                // Uses external process to retrieve temporary credentials
+                final String command = profile.getCredentialProcess();
+                final ObjectMapper mapper = JsonMapper.builder()
+                        .serializationInclusion(Include.NON_NULL)
+                        .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .visibility(PropertyAccessor.FIELD, Visibility.ANY).build();
+                List<String> cmd = new ArrayList<>();
+                switch(Factory.Platform.getDefault()) {
+                    case windows:
+                        cmd.add("cmd");
+                        cmd.add("/c");
+                        break;
+                    default:
+                        cmd.add("sh");
+                        cmd.add("-c");
+                        break;
+                }
+                cmd.add(command);
+                final ProcessBuilder builder = new ProcessBuilder(cmd);
+                try {
+                    final Process process = builder.start();
+                    try(InputStream reader = process.getInputStream()) {
+                        final CachedCredential cached = mapper.readValue(reader, CachedCredential.class);
+                        return credentials.setTokens(new TemporaryAccessTokens(
+                                cached.accessKey, cached.secretKey, cached.sessionToken, Instant.parse(cached.expiration).toEpochMilli()));
+                    }
+                }
+                catch(IOException e) {
+                    log.warn("Failure \"{}\" parsing cached credentials from {}", e.getMessage(), command);
+                    return credentials;
+                }
+            }
             if(profile.isRoleBasedProfile()) {
                 log.debug("Configure credentials from role based profile {}", profile.getProfileName());
                 if(StringUtils.isBlank(profile.getRoleSourceProfile())) {

--- a/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
+++ b/s3/src/main/java/ch/cyberduck/core/s3/S3CredentialsConfigurator.java
@@ -131,7 +131,6 @@ public class S3CredentialsConfigurator implements CredentialsConfigurator {
                         }
                         return credentials;
                     }
-
                     finally {
                         process.destroy();
                     }

--- a/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
+++ b/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
@@ -39,16 +39,14 @@ public class S3CredentialsConfiguratorTest {
     @Test
     public void readFailureForInvalidAWSCredentialsProfileEntry() throws Exception {
         final Credentials credentials = new Credentials("test_s3_profile");
-        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/invalid/.aws").getAbsolutePath())
-        )
+        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/invalid/.aws").getAbsolutePath()))
                 .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, credentials));
         assertEquals(credentials, verify);
     }
 
     @Test
     public void readSuccessForValidAWSCredentialsProfileEntry() throws Exception {
-        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath())
-        )
+        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
                 .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, new Credentials("test_s3_profile")));
         assertEquals("test_s3_profile", verify.getUsername());
         assertEquals("", verify.getPassword());
@@ -59,8 +57,7 @@ public class S3CredentialsConfiguratorTest {
 
     @Test
     public void readSSOCachedTemporaryTokens() throws Exception {
-        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath())
-        )
+        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
                 .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, new Credentials("ReadOnlyAccess-189584543480")));
         assertEquals("TESTACCESSKEY", verify.getTokens().getAccessKeyId());
         assertEquals("TESTSECRETKEY", verify.getTokens().getSecretAccessKey());
@@ -71,8 +68,7 @@ public class S3CredentialsConfiguratorTest {
     @Test
     public void readCredentialProcessTokens() throws Exception {
         Assume.assumeFalse("credential_process via sh not supported on Windows", System.getProperty("os.name", "").toLowerCase().contains("win"));
-        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath())
-        )
+        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
                 .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, new Credentials("credential_process_profile")));
         assertEquals("PROCESSACCESSKEY", verify.getTokens().getAccessKeyId());
         assertEquals("PROCESSSECRETKEY", verify.getTokens().getSecretAccessKey());

--- a/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
+++ b/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
@@ -76,4 +76,20 @@ public class S3CredentialsConfiguratorTest {
         assertEquals("PROCESSSESSIONTOKEN", verify.getTokens().getSessionToken());
         assertEquals(3497005724000L, verify.getTokens().getExpiryInMilliseconds(), 0L);
     }
+
+    @Test
+    public void readCredentialProcessTokensExitCode() throws Exception {
+        assumeFalse(Factory.Platform.getDefault().equals(Factory.Platform.Name.windows));
+        final Credentials credentials = new Credentials("credential_process_profile_error_exit");
+        assertEquals(credentials, new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
+                .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, credentials)));
+    }
+
+    @Test
+    public void readCredentialProcessTokensParseError() throws Exception {
+        assumeFalse(Factory.Platform.getDefault().equals(Factory.Platform.Name.windows));
+        final Credentials credentials = new Credentials("credential_process_profile_parser_error");
+        assertEquals(credentials, new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
+                .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, credentials)));
+    }
 }

--- a/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
+++ b/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
@@ -16,17 +16,18 @@ package ch.cyberduck.core.s3;
  */
 
 import ch.cyberduck.core.Credentials;
+import ch.cyberduck.core.Factory;
 import ch.cyberduck.core.Host;
 import ch.cyberduck.core.LocalFactory;
 import ch.cyberduck.core.TestProtocol;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 public class S3CredentialsConfiguratorTest {
 
@@ -67,7 +68,7 @@ public class S3CredentialsConfiguratorTest {
 
     @Test
     public void readCredentialProcessTokens() throws Exception {
-        Assume.assumeFalse("credential_process via sh not supported on Windows", System.getProperty("os.name", "").toLowerCase().contains("win"));
+        assumeFalse(Factory.Platform.getDefault().equals(Factory.Platform.Name.windows));
         final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath()))
                 .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, new Credentials("credential_process_profile")));
         assertEquals("PROCESSACCESSKEY", verify.getTokens().getAccessKeyId());

--- a/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
+++ b/s3/src/test/java/ch/cyberduck/core/s3/S3CredentialsConfiguratorTest.java
@@ -21,6 +21,7 @@ import ch.cyberduck.core.LocalFactory;
 import ch.cyberduck.core.TestProtocol;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
@@ -64,6 +65,18 @@ public class S3CredentialsConfiguratorTest {
         assertEquals("TESTACCESSKEY", verify.getTokens().getAccessKeyId());
         assertEquals("TESTSECRETKEY", verify.getTokens().getSecretAccessKey());
         assertEquals("TESTSESSIONTOKEN", verify.getTokens().getSessionToken());
+        assertEquals(3497005724000L, verify.getTokens().getExpiryInMilliseconds(), 0L);
+    }
+
+    @Test
+    public void readCredentialProcessTokens() throws Exception {
+        Assume.assumeFalse("credential_process via sh not supported on Windows", System.getProperty("os.name", "").toLowerCase().contains("win"));
+        final Credentials verify = new S3CredentialsConfigurator(LocalFactory.get(new File("src/test/resources/valid/.aws").getAbsolutePath())
+        )
+                .reload().configure(new Host(new TestProtocol(), StringUtils.EMPTY, new Credentials("credential_process_profile")));
+        assertEquals("PROCESSACCESSKEY", verify.getTokens().getAccessKeyId());
+        assertEquals("PROCESSSECRETKEY", verify.getTokens().getSecretAccessKey());
+        assertEquals("PROCESSSESSIONTOKEN", verify.getTokens().getSessionToken());
         assertEquals(3497005724000L, verify.getTokens().getExpiryInMilliseconds(), 0L);
     }
 }

--- a/s3/src/test/resources/valid/.aws/config
+++ b/s3/src/test/resources/valid/.aws/config
@@ -7,3 +7,9 @@ region = eu-west-1
 
 [profile credential_process_profile]
 credential_process = printf '{"Version": 1,"AccessKeyId":"PROCESSACCESSKEY","SecretAccessKey":"PROCESSSECRETKEY","SessionToken":"PROCESSSESSIONTOKEN","Expiration":"2080-10-24T14:28:44Z"}'
+
+[profile credential_process_profile_error_exit]
+credential_process = exit 1
+
+[profile credential_process_profile_parser_error]
+credential_process = printf '{"Version": 1'

--- a/s3/src/test/resources/valid/.aws/config
+++ b/s3/src/test/resources/valid/.aws/config
@@ -6,4 +6,4 @@ sso_role_name = ReadOnlyAccess
 region = eu-west-1
 
 [profile credential_process_profile]
-credential_process = printf '{"AccessKeyId":"PROCESSACCESSKEY","SecretAccessKey":"PROCESSSECRETKEY","SessionToken":"PROCESSSESSIONTOKEN","Expiration":"2080-10-24T14:28:44Z"}'
+credential_process = printf '{"Version": 1,"AccessKeyId":"PROCESSACCESSKEY","SecretAccessKey":"PROCESSSECRETKEY","SessionToken":"PROCESSSESSIONTOKEN","Expiration":"2080-10-24T14:28:44Z"}'

--- a/s3/src/test/resources/valid/.aws/config
+++ b/s3/src/test/resources/valid/.aws/config
@@ -4,3 +4,6 @@ sso_region = us-east-1
 sso_account_id = 189584543480
 sso_role_name = ReadOnlyAccess
 region = eu-west-1
+
+[profile credential_process_profile]
+credential_process = printf '{"AccessKeyId":"PROCESSACCESSKEY","SecretAccessKey":"PROCESSSECRETKEY","SessionToken":"PROCESSSESSIONTOKEN","Expiration":"2080-10-24T14:28:44Z"}'


### PR DESCRIPTION
Fix #11664.