### PR TITLE
Save default connection profile with `:` to seperate vendor string.

### DIFF
--- a/core/src/test/java/ch/cyberduck/core/ProtocolFactoryTest.java
+++ b/core/src/test/java/ch/cyberduck/core/ProtocolFactoryTest.java
@@ -276,11 +276,41 @@ public class ProtocolFactoryTest {
 
     @Test
     public void testForNameOrDefault() throws Exception {
-        final TestProtocol ftp = new TestProtocol(Scheme.ftp);
-        final TestProtocol dav = new TestProtocol(Scheme.dav);
-        final ProtocolFactory f = new ProtocolFactory(new LinkedHashSet<>(Arrays.asList(ftp, dav)));
-        assertEquals(dav, f.forNameOrDefault("dav"));
+        final TestProtocol ftp = new TestProtocol(Scheme.ftp) {
+            @Override
+            public String getIdentifier() {
+                return "test-ftp";
+            }
+        };
+        final TestProtocol dav = new TestProtocol(Scheme.dav) {
+            @Override
+            public String getIdentifier() {
+                return "test-dav";
+            }
+        };
+        final TestProtocol davProfileCustomprovider = new TestProtocol(Scheme.dav) {
+            @Override
+            public String getIdentifier() {
+                return "test-dav";
+            }
+
+            @Override
+            public String getProvider() {
+                return "custom";
+            }
+        };
+        final ProtocolFactory f = new ProtocolFactory(new LinkedHashSet<>(Arrays.asList(ftp, dav, davProfileCustomprovider)));
+        assertEquals(dav, f.forName("test-dav"));
+        assertEquals(dav, f.forNameOrDefault("test-dav"));
+        assertEquals(dav, f.forNameOrDefault("test-dav:test-dav"));
+        assertEquals(dav, f.forName("test-dav:test-dav"));
+        assertEquals(davProfileCustomprovider, f.forNameOrDefault("test-dav:custom"));
+        assertEquals(davProfileCustomprovider, f.forNameOrDefault("test-dav-custom"));
+        assertEquals(davProfileCustomprovider, f.forName("test-dav:custom"));
+        assertEquals(davProfileCustomprovider, f.forName("test-dav-custom"));
+        assertNull(f.forName("invalid"));
         assertEquals(ftp, f.forNameOrDefault("invalid"));
+        assertEquals(ftp, f.forNameOrDefault("test-ftp"));
         assertEquals(ftp, f.forNameOrDefault("ftp"));
     }
 

--- a/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
+++ b/osx/src/main/java/ch/cyberduck/ui/cocoa/controller/PreferencesController.java
@@ -1992,7 +1992,7 @@ public class PreferencesController extends ToolbarWindowController {
     @Action
     public void protocolComboboxClicked(NSPopUpButton sender) {
         final Protocol selected = ProtocolFactory.get().forName(sender.selectedItem().representedObject());
-        preferences.setProperty("connection.protocol.default", String.format("%s-%s", selected.getIdentifier(), selected.getProvider()));
+        preferences.setProperty("connection.protocol.default", String.format("%s:%s", selected.getIdentifier(), selected.getProvider()));
         preferences.setProperty("connection.port.default", selected.getDefaultPort());
     }
 

--- a/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
+++ b/windows/src/main/csharp/ch/cyberduck/ui/controller/PreferencesController.cs
@@ -851,7 +851,7 @@ namespace Ch.Cyberduck.Ui.Controller
         private void View_DefaultProtocolChangedEvent()
         {
             Protocol selected = View.DefaultProtocol;
-            PreferencesFactory.get().setProperty("connection.protocol.default", String.Format("{0}-{1}", selected.getIdentifier(), selected.getProvider()));
+            PreferencesFactory.get().setProperty("connection.protocol.default", String.Format("{0}:{1}", selected.getIdentifier(), selected.getProvider()));
             PreferencesFactory.get().setProperty("connection.port.default", selected.getDefaultPort());
         }
 


### PR DESCRIPTION
Fix #18090.