### PR TITLE
Fix MSBuild in VS2026 update validating Json Schema for .nupkg.metadata

### DIFF
--- a/src/main/msbuild/NuGet-Unpack.ps1
+++ b/src/main/msbuild/NuGet-Unpack.ps1
@@ -28,5 +28,5 @@ foreach ($line in Get-Content $PackagesListPath) {
     New-Item -Force -Type Directory $TargetDirectory
     Get-ChildItem $TargetDirectory | Remove-Item -Recurse -Force
     tar.exe xf $NupkgFile -C $TargetDirectory
-    Set-Content "$TargetDirectory\.nupkg.metadata" '{}'
+    Set-Content "$TargetDirectory\.nupkg.metadata" '{ "contentHash": "" }'
 }


### PR DESCRIPTION
They changed something.