### PR TITLE
Skip dir.uvf when decrypting directory contents.

### DIFF
--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -722,7 +722,7 @@ cryptomator.vault.masterkey.filename=masterkey.cryptomator
 cryptomator.vault.config.filename=vault.cryptomator
 cryptomator.vault.config.filename.uvf=vault.uvf
 cryptomator.vault.pepper=
-cryptomator.vault.skip.regex=dirid.c9r
+cryptomator.vault.skip.regex=dirid.c9r|dir.uvf
 cryptomator.cache.size=1000
 # Save passwords for vaults in Keychain
 cryptomator.vault.keychain=false

--- a/defaults/src/main/resources/default.properties
+++ b/defaults/src/main/resources/default.properties
@@ -722,7 +722,7 @@ cryptomator.vault.masterkey.filename=masterkey.cryptomator
 cryptomator.vault.config.filename=vault.cryptomator
 cryptomator.vault.config.filename.uvf=vault.uvf
 cryptomator.vault.pepper=
-cryptomator.vault.skip.regex=dirid.c9r|dir.uvf
+cryptomator.vault.skip.regex=dirid\\.c9r|dir\\.uvf
 cryptomator.cache.size=1000
 # Save passwords for vaults in Keychain
 cryptomator.vault.keychain=false


### PR DESCRIPTION
Fix #18099.