### PR TITLE
Skip installing Bonjour when instructed

### DIFF
--- a/windows/src/main/wix/Bootstrapper/Cyberduck Bootstrapper.wxs
+++ b/windows/src/main/wix/Bootstrapper/Cyberduck Bootstrapper.wxs
@@ -8,8 +8,8 @@
     <Variable Name="InstallBonjour" bal:Overridable="yes" Type="numeric" Value="1" />
 
     <!-- Do search for Bonjour Upgrade Code -->
-    <util:ProductSearch Id="HasBonjour" UpgradeCode="{46AE3251-43D6-41CF-8CDF-E902C38516D1}" Variable="Bonjour_VERSION64" Condition="InstallBonjour=0" />
-    <util:ProductSearch After="HasBonjour" Condition="Bonjour_VERSION64" UpgradeCode="{46AE3251-43D6-41CF-8CDF-E902C38516D1}" Variable="InstallBonjour" />
+    <!-- BonjourState: 1: Advertised, 2: Absent, 5: Locally Installed -->
+    <util:ProductSearch Id="BonjourState" UpgradeCode="{46AE3251-43D6-41CF-8CDF-E902C38516D1}" Result="state" Variable="BonjourState" />
 
     <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="Software\[WixBundleManufacturer]\[WixBundleName]" Value="InstallDir" Variable="PreviousInstallFolder" />
     <util:RegistrySearch Id="CurrentBuild" Variable="CBNumber" Result="value" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Value="CurrentBuildNumber" />
@@ -23,7 +23,7 @@
       <MsiPackage Id="Setup" Compressed="yes" SourceFile="$(Cyberduck.Bundle.TargetPath)" Vital="yes">
         <MsiProperty Name="INSTALLFOLDER" Value="[InstallFolder]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(SetupDir)Bonjour64.msi" Compressed="yes" Permanent="yes" Visible="yes" Vital="no" InstallCondition="NOT InstallBonjour=0" />
+      <MsiPackage SourceFile="$(SetupDir)Bonjour64.msi" Compressed="yes" Permanent="yes" Visible="yes" Vital="no" InstallCondition="NOT (InstallBonjour=0 AND BonjourState=2)" />
     </Chain>
   </Bundle>
 </Wix>


### PR DESCRIPTION
Wix v5 changed condition evaluation
Condition="0.0.0.0" isn't false anymore.

Fixes #18226 