### PR TITLE
SDSDirectS3WriteFeature does not work on its own.

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/worker/TouchWorker.java
+++ b/core/src/main/java/ch/cyberduck/core/worker/TouchWorker.java
@@ -28,6 +28,7 @@ import ch.cyberduck.core.exception.BackgroundException;
 import ch.cyberduck.core.features.AclPermission;
 import ch.cyberduck.core.features.AttributesFinder;
 import ch.cyberduck.core.features.Encryption;
+import ch.cyberduck.core.features.MultipartWrite;
 import ch.cyberduck.core.features.Redundancy;
 import ch.cyberduck.core.features.Touch;
 import ch.cyberduck.core.features.UnixPermission;
@@ -82,7 +83,12 @@ public class TouchWorker extends Worker<Path> {
                 status.setAcl(acl.getDefault(container));
             }
         }
-        final Path result = feature.touch(session.getFeature(Write.class), file, status);
+        Write writer = session.getFeature(MultipartWrite.class);
+        if(null == writer) {
+            // Fallback if multipart write is not available
+            writer = session.getFeature(Write.class);
+        }
+        final Path result = feature.touch(writer, file, status);
         if(PathAttributes.EMPTY.equals(result.attributes())) {
             return result.withAttributes(session.getFeature(AttributesFinder.class).find(result));
         }


### PR DESCRIPTION
**Root cause**

`FilesystemTouchWorker#isSupported` explicitly allows touch for the lock owner file even when `fs.touch.enable=false`. `TouchWorker` then calls `feature.touch()` using the session's generic `Write<Node>` feature, which for Dracoon/SDS (with `sds.upload.s3.enable=true`) resolved to `SDSDirectS3WriteFeature`.

That class assumes `status.getUrl()` (a presigned URL) is already set — true only when it's invoked as a per-part writer from `SDSDirectS3UploadFeature`, which fetches the presigned URLs beforehand. Called standalone, `status.getUrl()` is `null`, causing an NPE.

This is a regression from a4bf2db, which changed the touch feature to go through the session's generic `Write` feature instead of resolving the correct writer itself.

**Why reuse `SDSDirectS3MultipartWriteFeature` instead of patching `SDSDirectS3WriteFeature`**

The Dracoon direct-S3 API has no plain single-shot upload endpoint — every direct-S3 upload, even one that ends up as a single part, goes through the same channel:

`createFileUploadChannel` → `generatePresignedUrlsFiles` → `PUT` → `completeS3FileUpload`

`SDSDirectS3MultipartWriteFeature` already implements exactly this self-contained flow as a generic `Write<Node>`, fetching its own presigned URL and completing the upload without requiring a pre-set `status.getUrl()`.

`SDSDirectS3WriteFeature`, by contrast, only ever acts as the per-part writer used internally by `SDSDirectS3UploadFeature`, where the URL is always supplied by the caller — it was never meant to work on its own.