### PR TITLE
Resolve default path of bookmark with delimiter in file name (Google Drive)

### DIFF
--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveDefaultPathHomeFeature.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveDefaultPathHomeFeature.java
@@ -1,0 +1,108 @@
+package ch.cyberduck.core.googledrive;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.DefaultPathAttributes;
+import ch.cyberduck.core.Host;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.PathAttributes;
+import ch.cyberduck.core.PathNormalizer;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.AttributesFinder;
+import ch.cyberduck.core.features.Home;
+import ch.cyberduck.core.shared.AbstractHomeFeature;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.EnumSet;
+
+/**
+ * Resolve default path of bookmark. Names of files and Shared Drives in Google Drive may contain the path delimiter
+ * making the absolute path saved in the bookmark ambiguous. When no file is found for the default path interpreting
+ * every delimiter as separator, match the path segments against the file names found on the server.
+ */
+public class DriveDefaultPathHomeFeature extends AbstractHomeFeature {
+    private static final Logger log = LogManager.getLogger(DriveDefaultPathHomeFeature.class);
+
+    private final Host host;
+    private final AttributesFinder attributes;
+
+    public DriveDefaultPathHomeFeature(final Host host, final AttributesFinder attributes) {
+        this.host = host;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Path find() throws BackgroundException {
+        if(StringUtils.isBlank(host.getDefaultPath())) {
+            log.debug("No default path set for bookmark {}", host);
+            // No default path configured
+            return null;
+        }
+        final Path home = PathNormalizer.compose(Home.root(), host.getDefaultPath());
+        try {
+            return home.withAttributes(new DefaultPathAttributes(attributes.find(home)));
+        }
+        catch(NotfoundException e) {
+            log.warn("Failure {} finding default path {}. Match path segments against file names", e, home);
+            // Retry interpreting the delimiter in the default path as part of a file name
+            final Path resolved = this.resolve(Home.root(),
+                    StringUtils.split(PathNormalizer.normalize(host.getDefaultPath()), Path.DELIMITER), 0);
+            if(null == resolved) {
+                throw e;
+            }
+            return resolved;
+        }
+    }
+
+    /**
+     * Match segments of the default path against the listing of the directory. A single file name may span multiple
+     * segments when containing the path delimiter.
+     *
+     * @param directory Parent directory of the segment referenced with index
+     * @param segments  Path segments of the default path split by delimiter
+     * @param index     Index of the next segment to match
+     * @return Null if no file matching the remaining segments is found
+     */
+    protected Path resolve(final Path directory, final String[] segments, final int index) throws BackgroundException {
+        for(int last = index; last < segments.length; last++) {
+            // Join with subsequent segments to find file name containing the path delimiter
+            final String name = StringUtils.join(segments, Path.DELIMITER, index, last + 1);
+            final Path file = new Path(directory, name, EnumSet.of(Path.Type.directory));
+            final PathAttributes found;
+            try {
+                found = attributes.find(file);
+            }
+            catch(NotfoundException e) {
+                log.debug("No file {} found in directory {}", name, directory);
+                continue;
+            }
+            file.withAttributes(new DefaultPathAttributes(found));
+            if(last == segments.length - 1) {
+                return file;
+            }
+            final Path home = this.resolve(file, segments, last + 1);
+            if(null != home) {
+                return home;
+            }
+            log.debug("No match for remaining segments in directory {}", file);
+        }
+        return null;
+    }
+}

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveSession.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveSession.java
@@ -35,6 +35,8 @@ import ch.cyberduck.core.http.UserAgentHttpRequestInitializer;
 import ch.cyberduck.core.oauth.OAuth2ErrorResponseInterceptor;
 import ch.cyberduck.core.oauth.OAuth2RequestInterceptor;
 import ch.cyberduck.core.proxy.ProxyFinder;
+import ch.cyberduck.core.shared.DelegatingHomeFeature;
+import ch.cyberduck.core.shared.WorkdirHomeFeature;
 import ch.cyberduck.core.ssl.X509KeyManager;
 import ch.cyberduck.core.ssl.X509TrustManager;
 import ch.cyberduck.core.threading.CancelCallback;
@@ -178,6 +180,10 @@ public class DriveSession extends HttpSession<Drive> {
         }
         if(type == Versioning.class) {
             return (T) new DriveVersioningFeature(this, fileid);
+        }
+        if(type == Home.class) {
+            return (T) new DelegatingHomeFeature(new WorkdirHomeFeature(host),
+                    new DriveDefaultPathHomeFeature(host, new DriveAttributesFinderFeature(this, fileid)));
         }
         return super._getFeature(type);
     }

--- a/googledrive/src/test/java/ch/cyberduck/core/googledrive/DriveDefaultPathHomeFeatureTest.java
+++ b/googledrive/src/test/java/ch/cyberduck/core/googledrive/DriveDefaultPathHomeFeatureTest.java
@@ -1,0 +1,131 @@
+package ch.cyberduck.core.googledrive;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.DefaultPathAttributes;
+import ch.cyberduck.core.Host;
+import ch.cyberduck.core.ListProgressListener;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.PathAttributes;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.AttributesFinder;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DriveDefaultPathHomeFeatureTest {
+
+    @Test
+    public void testFindDefaultPath() throws Exception {
+        final Path home = new DriveDefaultPathHomeFeature(this.bookmark("/My Drive/Documents/Invoices"),
+                new TestAttributesFinder()
+                        .add("f1", "My Drive")
+                        .add("f2", "My Drive", "Documents")
+                        .add("f3", "My Drive", "Documents", "Invoices")).find();
+        assertNotNull(home);
+        assertEquals("Invoices", home.getName());
+        assertEquals("f3", home.attributes().getFileId());
+        assertEquals("Documents", home.getParent().getName());
+        assertEquals("My Drive", home.getParent().getParent().getName());
+        assertTrue(home.getParent().getParent().getParent().isRoot());
+    }
+
+    @Test
+    public void testFindSharedDriveNameWithDelimiter() throws Exception {
+        // Shared Drive named Либо/Либо with trailing space in bookmark /Shared Drives/Либо/Либо /Подкасты
+        final Path home = new DriveDefaultPathHomeFeature(this.bookmark("/Shared Drives/Либо/Либо /Подкасты"),
+                new TestAttributesFinder()
+                        .add("f1", "Shared Drives")
+                        .add("f2", "Shared Drives", "Либо/Либо ")
+                        .add("f3", "Shared Drives", "Либо/Либо ", "Подкасты")).find();
+        assertNotNull(home);
+        assertEquals("Подкасты", home.getName());
+        assertEquals("f3", home.attributes().getFileId());
+        assertEquals("Либо/Либо ", home.getParent().getName());
+        assertEquals("f2", home.getParent().attributes().getFileId());
+        assertEquals("Shared Drives", home.getParent().getParent().getName());
+    }
+
+    @Test
+    public void testFindBacktrackAmbiguousMatch() throws Exception {
+        // Both a Shared Drive named a and a Shared Drive named a/b exist with only the latter containing c
+        final Path home = new DriveDefaultPathHomeFeature(this.bookmark("/Shared Drives/a/b/c"),
+                new TestAttributesFinder()
+                        .add("f1", "Shared Drives")
+                        .add("f2", "Shared Drives", "a")
+                        .add("f3", "Shared Drives", "a/b")
+                        .add("f4", "Shared Drives", "a/b", "c")).find();
+        assertNotNull(home);
+        assertEquals("c", home.getName());
+        assertEquals("f4", home.attributes().getFileId());
+        assertEquals("a/b", home.getParent().getName());
+    }
+
+    @Test(expected = NotfoundException.class)
+    public void testFindNotfound() throws Exception {
+        new DriveDefaultPathHomeFeature(this.bookmark("/Shared Drives/a/b"),
+                new TestAttributesFinder().add("f1", "Shared Drives")).find();
+    }
+
+    @Test
+    public void testFindNoDefaultPath() throws Exception {
+        assertNull(new DriveDefaultPathHomeFeature(this.bookmark(null), new TestAttributesFinder()).find());
+    }
+
+    @Test
+    public void testFindRootDefaultPath() throws Exception {
+        assertTrue(new DriveDefaultPathHomeFeature(this.bookmark("/"), new TestAttributesFinder()).find().isRoot());
+    }
+
+    private Host bookmark(final String defaultpath) {
+        return new Host(new DriveProtocol(), "www.googleapis.com").setDefaultPath(defaultpath);
+    }
+
+    /**
+     * Lookup of files by name in parent directory ignoring the ambiguous absolute path
+     */
+    private static final class TestAttributesFinder implements AttributesFinder {
+        private final Map<List<String>, String> files = new HashMap<>();
+
+        public TestAttributesFinder add(final String fileid, final String... path) {
+            files.put(Arrays.asList(path), fileid);
+            return this;
+        }
+
+        @Override
+        public PathAttributes find(final Path file, final ListProgressListener listener) throws BackgroundException {
+            if(file.isRoot()) {
+                return PathAttributes.EMPTY;
+            }
+            final List<String> path = new LinkedList<>();
+            for(Path parent = file; !parent.isRoot(); parent = parent.getParent()) {
+                path.add(0, parent.getName());
+            }
+            if(!files.containsKey(path)) {
+                throw new NotfoundException(file.getAbsolute());
+            }
+            return new DefaultPathAttributes().setFileId(files.get(path));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17931.

### Problem

A bookmark pointing into a Shared Drive whose name contains `/` mounts the Google Drive root instead of the bookmarked folder.

Bookmarks persist the working directory as a single string in `defaultpath`. In Google Drive `/` is both the path delimiter and a legal character in file and Shared Drive names, so that string is ambiguous. For the bookmark in #17931, with a Shared Drive named `Либо/Либо `, the default path

```
/Shared Drives/Либо/Либо /Подкасты/Запуск завтра/14 сезон (видео!)
```

is split into the segments `Либо` and `Либо `. No Shared Drive by that name exists, `PathAttributesHomeFeature` fails with `NotfoundException detail='/Shared Drives/Либо'`, and `MountWorker` falls back to mounting `/` — which is what the user sees.

### Change

`DriveDefaultPathHomeFeature` resolves the default path of a bookmark and is registered as the `Home` feature in `DriveSession`.

It first composes the path exactly as `DefaultPathHomeFeature` does today, so behaviour and request count are unchanged for the common case. Only when that fails with `NotfoundException` does it match the segments of the default path against the file names on the server, joining consecutive segments with the delimiter and backtracking when a shorter match turns out to have no matching children (both a drive `a` and a drive `a/b` may exist).

### This is not a pretty solution, and I know it

Recovering the segmentation from an ambiguous string is guesswork, so the fallback is a heuristic:

* **Ambiguity is resolved arbitrarily.** If more than one reading of the path exists on the server, the shortest matching one wins. There is no correct answer — the information was lost when the bookmark was saved.
* **Not everything is recoverable.** Names containing `//` or a trailing delimiter do not survive `PathNormalizer.normalize` before this code runs.
* **No cap on the search.** In the pathological case where nearly every prefix matches an existing name, the number of lookups grows exponentially with the number of segments. In practice it is one lookup per level, and the search only runs after the fast path has already failed.

I went for it anyway because Google Drive bookmarks silently breaking is worse than an imperfect heuristic in a code path that today has no chance of succeeding at all. Consider it a stopgap.

### The proper fix, for what it is worth

The bookmark format can already express this without ambiguity. `Host` serializes the working directory as an object under `Workdir Dictionary` (`Host.java`, `HostDictionary.java`), where `Path` keeps `Name` and `Parent` as separate fields and carries `File Id` in its attributes — a name containing the delimiter round-trips fine. `WorkdirHomeFeature` is already first in the `Home` chain, so a persisted working directory would be used before anything in this PR. It is only cleared for bookmarks, in `BookmarkCollection#collectionItemAdded`.

Persisting it for bookmarks touches decisions I did not want to make in a bugfix: editing the path in the bookmark UI would have to invalidate the stored identifier, exported bookmarks and `.duck` files shared between accounts need a meaningful fallback, and there is a policy question about a file that was moved (same id, different path) versus deleted and recreated (same path, different id) — plus the same core is used by the CLI and Mountain Duck. Happy to look into it if you think it is the right direction.

Note this fallback would still be needed either way: default paths that arrive as a plain string — existing bookmarks, URLs, the command line, imports from other clients — remain ambiguous.

### Testing

`DriveDefaultPathHomeFeatureTest` covers the plain case, a Shared Drive name containing the delimiter, backtracking on an ambiguous match, not found, no default path and the root default path, against a stubbed `AttributesFinder`. Removing the fallback makes the two delimiter tests fail with the same `NotfoundException` as reported in the issue.

I could not run the integration tests of the module — no test account. I did verify the fix end to end against the actual Google Drive account from the issue, with a build of this branch:

```
WARN  DriveDefaultPathHomeFeature - Failure NotfoundException detail='/Shared Drives/Либо'
      finding default path .../14 сезон (видео!). Match path segments against file names
INFO  MountWorker - Mount path Path{path='/Shared Drives/Либо/Либо /Подкасты/Запуск завтра/14 сезон (видео!)'}
INFO  Retrieved chunk of 54 items in .../14 сезон (видео!)
```

Before the change the same bookmark logged `Fallback to mount path Path{path='/'}`.
