### PR TITLE
Add Thumbnail feature interface to retrieve preview images from server

### DIFF
--- a/core/src/main/java/ch/cyberduck/core/features/Thumbnail.java
+++ b/core/src/main/java/ch/cyberduck/core/features/Thumbnail.java
@@ -1,0 +1,49 @@
+package ch.cyberduck.core.features;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.BackgroundException;
+
+import java.io.InputStream;
+
+/**
+ * Retrieve thumbnail preview image generated on server for file
+ */
+@Optional
+public interface Thumbnail {
+
+    /**
+     * Retrieve thumbnail image for file from server
+     *
+     * @param file File on server
+     * @param size Requested dimension in pixels for the longest edge of the image. Implementations may return an image
+     *             with different dimensions than requested
+     * @return Stream to read encoded image data from. The image format is not specified but must be determined from
+     * the content such as PNG or JPEG
+     * @throws ch.cyberduck.core.exception.NotfoundException No thumbnail available for file
+     * @throws BackgroundException                           Failure retrieving thumbnail from server
+     */
+    InputStream thumbnail(Path file, int size) throws BackgroundException;
+
+    /**
+     * @param file File on server
+     * @return False when no thumbnail can be determined for file
+     */
+    default boolean isSupported(final Path file) {
+        return file.isFile();
+    }
+}

--- a/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxExceptionMappingService.java
+++ b/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxExceptionMappingService.java
@@ -274,6 +274,37 @@ public class DropboxExceptionMappingService extends AbstractExceptionMappingServ
                 }
             }
         }
+        if(failure instanceof ThumbnailV2ErrorException) {
+            final ThumbnailV2Error error = ((ThumbnailV2ErrorException) failure).errorValue;
+            if(error.isPath()) {
+                final LookupError lookup = error.getPathValue();
+                this.parse(buffer, lookup.toString());
+                switch(lookup.tag()) {
+                    case LOCKED:
+                        return new LockedException(buffer.toString(), failure);
+                    case NOT_FOUND:
+                    case NOT_FILE:
+                    case NOT_FOLDER:
+                        return new NotfoundException(buffer.toString(), failure);
+                    case MALFORMED_PATH:
+                    case RESTRICTED_CONTENT:
+                        return new AccessDeniedException(buffer.toString(), failure);
+                    case OTHER:
+                        return new InteroperabilityException(buffer.toString(), failure);
+                }
+            }
+            switch(error.tag()) {
+                case NOT_FOUND:
+                case UNSUPPORTED_EXTENSION:
+                case UNSUPPORTED_IMAGE:
+                case CONVERSION_ERROR:
+                    // No thumbnail available for file
+                    return new NotfoundException(buffer.toString(), failure);
+                case ENCRYPTED_CONTENT:
+                case ACCESS_DENIED:
+                    return new AccessDeniedException(buffer.toString(), failure);
+            }
+        }
         if(failure instanceof AccessErrorException) {
             final AccessError error = ((AccessErrorException) failure).getAccessError();
             this.parse(buffer, error.toString());

--- a/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxSession.java
+++ b/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxSession.java
@@ -190,6 +190,9 @@ public class DropboxSession extends HttpSession<CustomDbxRawClientV2> {
         if(type == Versioning.class) {
             return (T) new DropboxVersioningFeature(this);
         }
+        if(type == Thumbnail.class) {
+            return (T) new DropboxThumbnailFeature(this);
+        }
         if(type == PathContainerService.class) {
             return (T) new DropboxPathContainerService();
         }

--- a/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxThumbnailFeature.java
+++ b/dropbox/src/main/java/ch/cyberduck/core/dropbox/DropboxThumbnailFeature.java
@@ -1,0 +1,106 @@
+package ch.cyberduck.core.dropbox;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.PathContainerService;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.features.Thumbnail;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.InputStream;
+
+import com.dropbox.core.DbxDownloader;
+import com.dropbox.core.DbxException;
+import com.dropbox.core.v2.files.CustomDbxUserGetThumbnailV2Requests;
+import com.dropbox.core.v2.files.PathOrLink;
+import com.dropbox.core.v2.files.PreviewResult;
+import com.dropbox.core.v2.files.ThumbnailSize;
+
+public class DropboxThumbnailFeature implements Thumbnail {
+
+    private final DropboxSession session;
+    private final PathContainerService containerService;
+
+    public DropboxThumbnailFeature(final DropboxSession session) {
+        this.session = session;
+        this.containerService = new DropboxPathContainerService();
+    }
+
+    @Override
+    public InputStream thumbnail(final Path file, final int size) throws BackgroundException {
+        try {
+            final DbxDownloader<PreviewResult> downloader = CustomDbxUserGetThumbnailV2Requests.getThumbnailV2(
+                    session.getClient(file), PathOrLink.path(containerService.getKey(file)), toThumbnailSize(size));
+            return downloader.getInputStream();
+        }
+        catch(DbxException e) {
+            throw new DropboxExceptionMappingService().map("Download {0} failed", e, file);
+        }
+    }
+
+    /**
+     * @return Smallest thumbnail size with longest edge greater than or equal to the requested size
+     */
+    protected static ThumbnailSize toThumbnailSize(final int size) {
+        if(size <= 32) {
+            return ThumbnailSize.W32H32;
+        }
+        if(size <= 64) {
+            return ThumbnailSize.W64H64;
+        }
+        if(size <= 128) {
+            return ThumbnailSize.W128H128;
+        }
+        if(size <= 256) {
+            return ThumbnailSize.W256H256;
+        }
+        if(size <= 480) {
+            return ThumbnailSize.W480H320;
+        }
+        if(size <= 640) {
+            return ThumbnailSize.W640H480;
+        }
+        if(size <= 960) {
+            return ThumbnailSize.W960H640;
+        }
+        if(size <= 1024) {
+            return ThumbnailSize.W1024H768;
+        }
+        if(size <= 2048) {
+            return ThumbnailSize.W2048H1536;
+        }
+        return ThumbnailSize.W3200H2400;
+    }
+
+    /**
+     * This method currently supports files with the following file extensions: jpg, jpeg, png, tiff, tif, gif,
+     * webp, ppm and bmp. Photos that are larger than 20MB in size won't be converted to a thumbnail.
+     */
+    @Override
+    public boolean isSupported(final Path file) {
+        if(!file.isFile()) {
+            return false;
+        }
+        if(file.attributes().getSize() > 20 * 1024 * 1024) {
+            return false;
+        }
+        return StringUtils.equalsAnyIgnoreCase(FilenameUtils.getExtension(file.getName()),
+                "jpg", "jpeg", "png", "tiff", "tif", "gif", "webp", "ppm", "bmp");
+    }
+}

--- a/dropbox/src/main/java/com/dropbox/core/v2/files/CustomDbxUserGetThumbnailV2Requests.java
+++ b/dropbox/src/main/java/com/dropbox/core/v2/files/CustomDbxUserGetThumbnailV2Requests.java
@@ -1,0 +1,86 @@
+package com.dropbox.core.v2.files;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import java.io.IOException;
+import java.util.Collections;
+
+import com.dropbox.core.DbxDownloader;
+import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxWrappedException;
+import com.dropbox.core.stone.StructSerializer;
+import com.dropbox.core.v2.DbxRawClientV2;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+
+/**
+ * Replacement for {@link DbxUserFilesRequests#getThumbnailV2Builder} serializing the request argument without the
+ * quality field rejected by the server with <code>Error in call to API function "files/get_thumbnail_v2":
+ * unexpected key 'quality'</code>.
+ */
+public final class CustomDbxUserGetThumbnailV2Requests {
+
+    private CustomDbxUserGetThumbnailV2Requests() {
+        //
+    }
+
+    /**
+     * Serializer for {@link ThumbnailV2Arg} omitting the quality field
+     */
+    private static final StructSerializer<ThumbnailV2Arg> SERIALIZER = new StructSerializer<ThumbnailV2Arg>() {
+        @Override
+        public void serialize(final ThumbnailV2Arg value, final JsonGenerator g, final boolean collapse) throws IOException {
+            if(!collapse) {
+                g.writeStartObject();
+            }
+            g.writeFieldName("resource");
+            PathOrLink.Serializer.INSTANCE.serialize(value.getResource(), g);
+            g.writeFieldName("format");
+            ThumbnailFormat.Serializer.INSTANCE.serialize(value.getFormat(), g);
+            g.writeFieldName("size");
+            ThumbnailSize.Serializer.INSTANCE.serialize(value.getSize(), g);
+            g.writeFieldName("mode");
+            ThumbnailMode.Serializer.INSTANCE.serialize(value.getMode(), g);
+            if(!collapse) {
+                g.writeEndObject();
+            }
+        }
+
+        @Override
+        public ThumbnailV2Arg deserialize(final JsonParser p, final boolean collapsed) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    public static DbxDownloader<PreviewResult> getThumbnailV2(final DbxRawClientV2 client, final PathOrLink resource,
+                                                              final ThumbnailSize size) throws ThumbnailV2ErrorException, DbxException {
+        final ThumbnailV2Arg arg = ThumbnailV2Arg.newBuilder(resource).withSize(size).build();
+        try {
+            return client.downloadStyle(client.getHost().getContent(),
+                    "2/files/get_thumbnail_v2",
+                    arg,
+                    false,
+                    Collections.emptyList(),
+                    SERIALIZER,
+                    PreviewResult.Serializer.INSTANCE,
+                    ThumbnailV2Error.Serializer.INSTANCE);
+        }
+        catch(DbxWrappedException ex) {
+            throw new ThumbnailV2ErrorException("2/files/get_thumbnail_v2", ex.getRequestId(), ex.getUserMessage(),
+                    (ThumbnailV2Error) ex.getErrorValue());
+        }
+    }
+}

--- a/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxThumbnailFeatureTest.java
+++ b/dropbox/src/test/java/ch/cyberduck/core/dropbox/DropboxThumbnailFeatureTest.java
@@ -1,0 +1,96 @@
+package ch.cyberduck.core.dropbox;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.AbstractDropboxTest;
+import ch.cyberduck.core.AlphanumericRandomStringService;
+import ch.cyberduck.core.ConnectionCallback;
+import ch.cyberduck.core.LoginCallback;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.Delete;
+import ch.cyberduck.core.features.Thumbnail;
+import ch.cyberduck.core.io.StreamCopier;
+import ch.cyberduck.core.shared.DefaultHomeFinderService;
+import ch.cyberduck.core.transfer.TransferStatus;
+import ch.cyberduck.test.IntegrationTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import com.dropbox.core.v2.files.ThumbnailSize;
+
+import static org.junit.Assert.*;
+
+@Category(IntegrationTest.class)
+public class DropboxThumbnailFeatureTest extends AbstractDropboxTest {
+
+    @Test
+    public void testToThumbnailSize() {
+        assertEquals(ThumbnailSize.W32H32, DropboxThumbnailFeature.toThumbnailSize(16));
+        assertEquals(ThumbnailSize.W32H32, DropboxThumbnailFeature.toThumbnailSize(32));
+        assertEquals(ThumbnailSize.W256H256, DropboxThumbnailFeature.toThumbnailSize(150));
+        assertEquals(ThumbnailSize.W1024H768, DropboxThumbnailFeature.toThumbnailSize(1024));
+        assertEquals(ThumbnailSize.W3200H2400, DropboxThumbnailFeature.toThumbnailSize(4096));
+    }
+
+    @Test
+    public void testIsSupported() {
+        final Thumbnail feature = new DropboxThumbnailFeature(session);
+        assertTrue(feature.isSupported(new Path("/f.png", EnumSet.of(Path.Type.file))));
+        assertTrue(feature.isSupported(new Path("/f.JPG", EnumSet.of(Path.Type.file))));
+        assertFalse(feature.isSupported(new Path("/f.pdf", EnumSet.of(Path.Type.file))));
+        assertFalse(feature.isSupported(new Path("/f.png", EnumSet.of(Path.Type.directory))));
+        assertFalse(feature.isSupported(new Path("/f", EnumSet.of(Path.Type.file))));
+    }
+
+    @Test(expected = NotfoundException.class)
+    public void testThumbnailNotFound() throws Exception {
+        final Path drive = new DefaultHomeFinderService(session).find();
+        new DropboxThumbnailFeature(session).thumbnail(
+                new Path(drive, String.format("%s.png", new AlphanumericRandomStringService().random()), EnumSet.of(Path.Type.file)), 150);
+    }
+
+    @Test
+    public void testThumbnail() throws Exception {
+        final Path drive = new DefaultHomeFinderService(session).find();
+        final Path test = new Path(drive, String.format("%s.png", new AlphanumericRandomStringService().random()), EnumSet.of(Path.Type.file));
+        final BufferedImage image = new BufferedImage(320, 240, BufferedImage.TYPE_INT_RGB);
+        final ByteArrayOutputStream container = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", container);
+        final byte[] content = container.toByteArray();
+        final TransferStatus status = new TransferStatus().setLength(content.length);
+        final OutputStream out = new DropboxWriteFeature(session).write(test, status, ConnectionCallback.noop);
+        new StreamCopier(new TransferStatus(), new TransferStatus()).transfer(new ByteArrayInputStream(content), out);
+        final InputStream in = new DropboxThumbnailFeature(session).thumbnail(test, 150);
+        assertNotNull(in);
+        final byte[] thumbnail = IOUtils.toByteArray(in);
+        in.close();
+        assertNotEquals(0, thumbnail.length);
+        assertNotNull(ImageIO.read(new ByteArrayInputStream(thumbnail)));
+        new DropboxDeleteFeature(session).delete(Collections.singletonList(test), LoginCallback.noop, new Delete.DisabledCallback());
+    }
+}

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveSession.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveSession.java
@@ -179,6 +179,9 @@ public class DriveSession extends HttpSession<Drive> {
         if(type == Versioning.class) {
             return (T) new DriveVersioningFeature(this, fileid);
         }
+        if(type == Thumbnail.class) {
+            return (T) new DriveThumbnailFeature(this, fileid);
+        }
         return super._getFeature(type);
     }
 

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveThumbnailFeature.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveThumbnailFeature.java
@@ -1,0 +1,78 @@
+package ch.cyberduck.core.googledrive;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.Thumbnail;
+import ch.cyberduck.core.http.DefaultHttpResponseExceptionMappingService;
+import ch.cyberduck.core.http.HttpMethodReleaseInputStream;
+import ch.cyberduck.core.preferences.HostPreferencesFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.google.api.services.drive.model.File;
+
+public class DriveThumbnailFeature implements Thumbnail {
+    private static final Logger log = LogManager.getLogger(DriveThumbnailFeature.class);
+
+    private final DriveSession session;
+    private final DriveFileIdProvider fileid;
+
+    public DriveThumbnailFeature(final DriveSession session, final DriveFileIdProvider fileid) {
+        this.session = session;
+        this.fileid = fileid;
+    }
+
+    @Override
+    public InputStream thumbnail(final Path file, final int size) throws BackgroundException {
+        try {
+            final File f = session.getClient().files().get(fileid.getFileId(file))
+                    .setFields("thumbnailLink")
+                    .setSupportsTeamDrives(HostPreferencesFactory.get(session.getHost()).getBoolean("googledrive.teamdrive.enable"))
+                    .execute();
+            final String link = f.getThumbnailLink();
+            if(StringUtils.isBlank(link)) {
+                log.warn("No thumbnail available for file {}", file);
+                throw new NotfoundException(file.getAbsolute());
+            }
+            // Short-lived URL must be fetched with credentialed request. Size of image returned defaults
+            // to 220 pixels on the longest edge adjustable with the trailing size parameter
+            final HttpGet request = new HttpGet(size > 0 ? link.replaceFirst("=s\\d+$", String.format("=s%d", size)) : link);
+            final HttpResponse response = session.getHttpClient().execute(request);
+            switch(response.getStatusLine().getStatusCode()) {
+                case HttpStatus.SC_OK:
+                    return new HttpMethodReleaseInputStream(response);
+                default:
+                    throw new DefaultHttpResponseExceptionMappingService().map("Download {0} failed", new HttpResponseException(
+                            response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()), file);
+            }
+        }
+        catch(IOException e) {
+            throw new DriveExceptionMappingService(fileid).map("Download {0} failed", e, file);
+        }
+    }
+}

--- a/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveThumbnailFeature.java
+++ b/googledrive/src/main/java/ch/cyberduck/core/googledrive/DriveThumbnailFeature.java
@@ -28,6 +28,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,6 +68,7 @@ public class DriveThumbnailFeature implements Thumbnail {
                 case HttpStatus.SC_OK:
                     return new HttpMethodReleaseInputStream(response);
                 default:
+                    EntityUtils.consumeQuietly(response.getEntity());
                     throw new DefaultHttpResponseExceptionMappingService().map("Download {0} failed", new HttpResponseException(
                             response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()), file);
             }

--- a/googledrive/src/test/java/ch/cyberduck/core/googledrive/DriveThumbnailFeatureTest.java
+++ b/googledrive/src/test/java/ch/cyberduck/core/googledrive/DriveThumbnailFeatureTest.java
@@ -1,0 +1,87 @@
+package ch.cyberduck.core.googledrive;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.AlphanumericRandomStringService;
+import ch.cyberduck.core.ConnectionCallback;
+import ch.cyberduck.core.LoginCallback;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.Delete;
+import ch.cyberduck.core.features.Thumbnail;
+import ch.cyberduck.core.http.HttpResponseOutputStream;
+import ch.cyberduck.core.io.StreamCopier;
+import ch.cyberduck.core.transfer.TransferStatus;
+import ch.cyberduck.test.IntegrationTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import com.google.api.services.drive.model.File;
+
+import static org.junit.Assert.*;
+
+@Category(IntegrationTest.class)
+public class DriveThumbnailFeatureTest extends AbstractDriveTest {
+
+    @Test(expected = NotfoundException.class)
+    public void testThumbnailNotFound() throws Exception {
+        new DriveThumbnailFeature(session, new DriveFileIdProvider(session)).thumbnail(
+                new Path(DriveHomeFinderService.MYDRIVE_FOLDER, new AlphanumericRandomStringService().random(), EnumSet.of(Path.Type.file)), 150);
+    }
+
+    @Test
+    public void testThumbnail() throws Exception {
+        final DriveFileIdProvider fileid = new DriveFileIdProvider(session);
+        final Path test = new Path(DriveHomeFinderService.MYDRIVE_FOLDER,
+                String.format("%s.png", new AlphanumericRandomStringService().random()), EnumSet.of(Path.Type.file));
+        final BufferedImage image = new BufferedImage(320, 240, BufferedImage.TYPE_INT_RGB);
+        final ByteArrayOutputStream container = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", container);
+        final byte[] content = container.toByteArray();
+        final TransferStatus status = new TransferStatus().setLength(content.length);
+        final HttpResponseOutputStream<File> out = new DriveWriteFeature(session, fileid).write(test, status, ConnectionCallback.noop);
+        new StreamCopier(new TransferStatus(), new TransferStatus()).transfer(new ByteArrayInputStream(content), out);
+        final Thumbnail feature = new DriveThumbnailFeature(session, fileid);
+        assertTrue(feature.isSupported(test));
+        InputStream in = null;
+        for(int i = 0; i < 10; i++) {
+            try {
+                in = feature.thumbnail(test, 150);
+                break;
+            }
+            catch(NotfoundException e) {
+                // Thumbnail generation on server is asynchronous
+                Thread.sleep(3000L);
+            }
+        }
+        assertNotNull(in);
+        final byte[] thumbnail = IOUtils.toByteArray(in);
+        in.close();
+        assertNotEquals(0, thumbnail.length);
+        assertNotNull(ImageIO.read(new ByteArrayInputStream(thumbnail)));
+        new DriveDeleteFeature(session, fileid).delete(Collections.singletonList(test), LoginCallback.noop, new Delete.DisabledCallback());
+    }
+}

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphSession.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/GraphSession.java
@@ -304,6 +304,9 @@ public abstract class GraphSession extends HttpSession<OneDriveAPI> {
         if(type == Versioning.class) {
             return (T) new GraphVersioningFeature(this, fileid);
         }
+        if(type == Thumbnail.class) {
+            return (T) new GraphThumbnailFeature(this, fileid);
+        }
         return super._getFeature(type);
     }
 

--- a/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/GraphThumbnailFeature.java
+++ b/onedrive/src/main/java/ch/cyberduck/core/onedrive/features/GraphThumbnailFeature.java
@@ -1,0 +1,72 @@
+package ch.cyberduck.core.onedrive.features;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.DefaultIOExceptionMappingService;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.features.Thumbnail;
+import ch.cyberduck.core.onedrive.GraphExceptionMappingService;
+import ch.cyberduck.core.onedrive.GraphSession;
+
+import org.nuxeo.onedrive.client.OneDriveAPIException;
+import org.nuxeo.onedrive.client.OneDriveRequest;
+import org.nuxeo.onedrive.client.OneDriveResponse;
+import org.nuxeo.onedrive.client.OneDriveRuntimeException;
+import org.nuxeo.onedrive.client.URLTemplate;
+import org.nuxeo.onedrive.client.types.DriveItem;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class GraphThumbnailFeature implements Thumbnail {
+
+    private final GraphSession session;
+    private final GraphFileIdProvider fileid;
+
+    public GraphThumbnailFeature(final GraphSession session, final GraphFileIdProvider fileid) {
+        this.session = session;
+        this.fileid = fileid;
+    }
+
+    @Override
+    public InputStream thumbnail(final Path file, final int size) throws BackgroundException {
+        try {
+            final DriveItem target = session.getItem(file);
+            // Custom thumbnail size fitting inside a box of the requested size maintaining aspect ratio
+            final URL url = new URLTemplate(target.getAction(String.format("/thumbnails/0/c%1$dx%1$d/content", size)))
+                    .build(target.getApi().getBaseURL());
+            final OneDriveRequest request = new OneDriveRequest(url, "GET");
+            final OneDriveResponse response = request.sendRequest(target.getApi().getExecutor());
+            return response.getContent();
+        }
+        catch(OneDriveAPIException e) {
+            throw new GraphExceptionMappingService(fileid).map("Download {0} failed", e, file);
+        }
+        catch(IOException e) {
+            throw new DefaultIOExceptionMappingService().map("Download {0} failed", e, file);
+        }
+        catch(OneDriveRuntimeException e) {
+            throw new GraphExceptionMappingService(fileid).map("Download {0} failed", e.getCause(), file);
+        }
+    }
+
+    @Override
+    public boolean isSupported(final Path file) {
+        return file.isFile() && !file.isPlaceholder();
+    }
+}

--- a/onedrive/src/test/java/ch/cyberduck/core/onedrive/GraphThumbnailFeatureTest.java
+++ b/onedrive/src/test/java/ch/cyberduck/core/onedrive/GraphThumbnailFeatureTest.java
@@ -1,0 +1,88 @@
+package ch.cyberduck.core.onedrive;
+
+/*
+ * Copyright (c) 2002-2026 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.AlphanumericRandomStringService;
+import ch.cyberduck.core.ConnectionCallback;
+import ch.cyberduck.core.LoginCallback;
+import ch.cyberduck.core.Path;
+import ch.cyberduck.core.exception.NotfoundException;
+import ch.cyberduck.core.features.Delete;
+import ch.cyberduck.core.features.Thumbnail;
+import ch.cyberduck.core.io.StreamCopier;
+import ch.cyberduck.core.onedrive.features.GraphDeleteFeature;
+import ch.cyberduck.core.onedrive.features.GraphThumbnailFeature;
+import ch.cyberduck.core.onedrive.features.GraphWriteFeature;
+import ch.cyberduck.core.transfer.TransferStatus;
+import ch.cyberduck.test.IntegrationTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.junit.Assert.*;
+
+@Category(IntegrationTest.class)
+public class GraphThumbnailFeatureTest extends AbstractOneDriveTest {
+
+    @Test(expected = NotfoundException.class)
+    public void testThumbnailNotFound() throws Exception {
+        final Path drive = new OneDriveHomeFinderService().find();
+        new GraphThumbnailFeature(session, fileid).thumbnail(
+                new Path(drive, String.format("%s.png", new AlphanumericRandomStringService().random()), EnumSet.of(Path.Type.file)), 150);
+    }
+
+    @Test
+    public void testThumbnail() throws Exception {
+        final Path drive = new OneDriveHomeFinderService().find();
+        final Path test = new Path(drive, String.format("%s.png", new AlphanumericRandomStringService().random()), EnumSet.of(Path.Type.file));
+        final BufferedImage image = new BufferedImage(320, 240, BufferedImage.TYPE_INT_RGB);
+        final ByteArrayOutputStream container = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", container);
+        final byte[] content = container.toByteArray();
+        final TransferStatus status = new TransferStatus().setLength(content.length);
+        final OutputStream out = new GraphWriteFeature(session, fileid).write(test, status, ConnectionCallback.noop);
+        new StreamCopier(new TransferStatus(), new TransferStatus()).transfer(new ByteArrayInputStream(content), out);
+        final Thumbnail feature = new GraphThumbnailFeature(session, fileid);
+        assertTrue(feature.isSupported(test));
+        InputStream in = null;
+        for(int i = 0; i < 10; i++) {
+            try {
+                in = feature.thumbnail(test, 150);
+                break;
+            }
+            catch(NotfoundException e) {
+                // Thumbnail generation on server is asynchronous
+                Thread.sleep(3000L);
+            }
+        }
+        assertNotNull(in);
+        final byte[] thumbnail = IOUtils.toByteArray(in);
+        in.close();
+        assertNotEquals(0, thumbnail.length);
+        assertNotNull(ImageIO.read(new ByteArrayInputStream(thumbnail)));
+        new GraphDeleteFeature(session, fileid).delete(Collections.singletonList(test), LoginCallback.noop, new Delete.DisabledCallback());
+    }
+}


### PR DESCRIPTION
Adds a new optional feature interface `ch.cyberduck.core.features.Thumbnail` providing preview images generated on the server, required to display thumbnails in Mountain Duck (iterate-ch/mountainduck#2655, iterate-ch/mountainduck#2580).

### Interface

```java
InputStream thumbnail(Path file, int size) throws BackgroundException;
```

- Returns a stream of encoded image data (PNG or JPEG); the consumer decodes with its native imaging API (WIC/`SoftwareBitmap` on Windows, `NSImage` on macOS). Avoids an AWT dependency in core and matches the `Read` idiom.
- `size` is the requested dimension in pixels for the longest edge, matching the semantics of `IThumbnailProvider::GetThumbnail(UINT cx, …)`. Implementations may return different dimensions.
- Throws `NotfoundException` when no thumbnail is available; `isSupported(Path)` allows a cheap preflight check.

### Implementations

**Google Drive.** Reads `thumbnailLink` from `files.get` and fetches the short-lived URL with a credentialed request through the session HTTP client as required for non-public files. Size is adjusted with the trailing `=s{size}` parameter. No documented list of supported formats; the definitive per-file signal is only available from the API.

**Dropbox.** Uses `files/get_thumbnail_v2` mapping the requested size to the closest fixed `ThumbnailSize`. The SDK (7.1.1) unconditionally serializes a `quality` field the server rejects with `unexpected key 'quality'`, on both `get_thumbnail` and `get_thumbnail_v2`; `CustomDbxUserGetThumbnailV2Requests` invokes the route via `downloadStyle` with a serializer omitting the field, following the `CustomDbxRawClientV2` pattern. `isSupported` filters by the file extensions documented in the API reference (jpg, jpeg, png, tiff, tif, gif, webp, ppm, bmp; 20 MB limit). `ThumbnailV2ErrorException` is mapped in `DropboxExceptionMappingService` (`unsupported_extension`/`unsupported_image`/`conversion_error`/`not_found` → `NotfoundException`).

**OneDrive/SharePoint.** Requests `GET {item}/thumbnails/0/c{size}x{size}/content` (documented custom size, bounded box preserving aspect ratio) built from the drive-scoped `DriveItem`, working for OneDrive Personal, Business, SharePoint libraries and shared items. No change to onedrive-java-client needed; the request is built with the public `URLTemplate`/`OneDriveRequest` API analogous to `Files.download`. A `Files.thumbnail` helper could be upstreamed later.

### Tests

Integration tests for all three protocols with a PNG upload round trip asserting decodable image content, plus not-found and `isSupported`/size-mapping cases. Dropbox tests pass against the live API; Drive and Graph tests follow the same pattern (thumbnail generation is asynchronous there, handled with retries).