### PR TITLE
feat: GSSAPI/Kerberos authentication for SFTP

### DIFF
--- a/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/SFTPSession.java
@@ -33,6 +33,7 @@ import ch.cyberduck.core.proxy.ProxyFinder;
 import ch.cyberduck.core.proxy.ProxySocketFactory;
 import ch.cyberduck.core.sftp.auth.SFTPAgentAuthentication;
 import ch.cyberduck.core.sftp.auth.SFTPChallengeResponseAuthentication;
+import ch.cyberduck.core.sftp.auth.SFTPGssApiAuthentication;
 import ch.cyberduck.core.sftp.auth.SFTPNoneAuthentication;
 import ch.cyberduck.core.sftp.auth.SFTPPasswordAuthentication;
 import ch.cyberduck.core.sftp.auth.SFTPPublicKeyAuthentication;
@@ -295,6 +296,7 @@ public class SFTPSession extends Session<SSHClient> {
             }
         }
         defaultMethods.add(new SFTPPublicKeyAuthentication(client));
+        defaultMethods.add(new SFTPGssApiAuthentication(client));
         if(credentials.isPasswordAuthentication()) {
             defaultMethods.add(0, new SFTPPasswordAuthentication(client));
             defaultMethods.add(0, new SFTPChallengeResponseAuthentication(client));

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
@@ -83,7 +83,10 @@ public class SFTPGssApiAuthentication implements AuthenticationProvider<Boolean>
         final String savedKrb5Conf = System.getProperty("java.security.krb5.conf");
         final String savedSubjectCredsOnly = System.getProperty("javax.security.auth.useSubjectCredsOnly");
         File krb5conf = null;
-        if(parts.length >= 2) {
+        if(savedKrb5Conf == null && parts.length >= 2) {
+            // Only apply the macOS workaround when no explicit krb5.conf is already configured.
+            // If the user or system has set java.security.krb5.conf we leave it untouched so
+            // that working Linux/macOS environments with a real KDC configuration are unaffected.
             final String realm = (parts[parts.length - 2] + "." + parts[parts.length - 1]).toUpperCase(java.util.Locale.ROOT);
             log.debug("Derived Kerberos realm {} from hostname {}", realm, hostname);
             try {

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
@@ -127,7 +127,7 @@ public class SFTPGssApiAuthentication implements AuthenticationProvider<Boolean>
             loginContext = new LoginContext("cyberduck-sftp", new Subject(), null, jaasConfig);
             loginContext.login();
             loggedIn = true;
-            log.debug("Kerberos TGT acquired for principal {}", loginContext.getSubject());
+            log.debug("Kerberos TGT acquired for principals {}", loginContext.getSubject().getPrincipals());
             final List<Oid> mechanisms = Collections.singletonList(KRB5_MECH);
             System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
             try {

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
@@ -133,26 +133,7 @@ public class SFTPGssApiAuthentication implements AuthenticationProvider<Boolean>
             log.debug("Kerberos TGT acquired for principals {}", loginContext.getSubject().getPrincipals());
             final List<Oid> mechanisms = Collections.singletonList(KRB5_MECH);
             System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
-            try {
-                client.auth(credentials.getUsername(), new AuthGssApiWithMic(loginContext, mechanisms));
-            }
-            finally {
-                if(savedKrb5Conf != null) {
-                    System.setProperty("java.security.krb5.conf", savedKrb5Conf);
-                }
-                else {
-                    System.clearProperty("java.security.krb5.conf");
-                }
-                if(savedSubjectCredsOnly != null) {
-                    System.setProperty("javax.security.auth.useSubjectCredsOnly", savedSubjectCredsOnly);
-                }
-                else {
-                    System.clearProperty("javax.security.auth.useSubjectCredsOnly");
-                }
-                if(krb5conf != null) {
-                    krb5conf.delete();
-                }
-            }
+            client.auth(credentials.getUsername(), new AuthGssApiWithMic(loginContext, mechanisms));
             final boolean authenticated = client.isAuthenticated();
             log.debug("GSS-API authentication result: authenticated={}, partialSuccess={}", authenticated,
                     client.getUserAuth().hadPartialSuccess());
@@ -168,6 +149,23 @@ public class SFTPGssApiAuthentication implements AuthenticationProvider<Boolean>
             return false;
         }
         finally {
+            // Always restore system properties and delete the temp file regardless of how we exit —
+            // including the LoginException path where client.auth() is never reached.
+            if(savedKrb5Conf != null) {
+                System.setProperty("java.security.krb5.conf", savedKrb5Conf);
+            }
+            else {
+                System.clearProperty("java.security.krb5.conf");
+            }
+            if(savedSubjectCredsOnly != null) {
+                System.setProperty("javax.security.auth.useSubjectCredsOnly", savedSubjectCredsOnly);
+            }
+            else {
+                System.clearProperty("javax.security.auth.useSubjectCredsOnly");
+            }
+            if(krb5conf != null) {
+                krb5conf.delete();
+            }
             if(loggedIn) {
                 try {
                     loginContext.logout();

--- a/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
+++ b/ssh/src/main/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthentication.java
@@ -1,0 +1,183 @@
+package ch.cyberduck.core.sftp.auth;
+
+/*
+ * Copyright (c) 2002-2017 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.AuthenticationProvider;
+import ch.cyberduck.core.Credentials;
+import ch.cyberduck.core.Host;
+import ch.cyberduck.core.LoginCallback;
+import ch.cyberduck.core.exception.BackgroundException;
+import ch.cyberduck.core.sftp.SFTPExceptionMappingService;
+import ch.cyberduck.core.threading.CancelCallback;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ietf.jgss.Oid;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.userauth.method.AuthGssApiWithMic;
+
+public class SFTPGssApiAuthentication implements AuthenticationProvider<Boolean> {
+    private static final Logger log = LogManager.getLogger(SFTPGssApiAuthentication.class);
+
+    /**
+     * Kerberos v5 mechanism OID (1.2.840.113554.1.2.2) as advertised by OpenSSH servers
+     * with <code>GSSAPIAuthentication yes</code>.
+     */
+    private static final Oid KRB5_MECH;
+    static {
+        try {
+            KRB5_MECH = new Oid("1.2.840.113554.1.2.2");
+        }
+        catch(org.ietf.jgss.GSSException e) {
+            // Cannot happen for a well-formed literal OID
+            throw new IllegalStateException("Failed to encode Kerberos v5 OID", e);
+        }
+    }
+
+    private final SSHClient client;
+
+    public SFTPGssApiAuthentication(final SSHClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Boolean authenticate(final Host bookmark, final LoginCallback prompt, final CancelCallback cancel)
+            throws BackgroundException {
+        final Credentials credentials = bookmark.getCredentials();
+        log.debug("Login using GSS-API/Kerberos authentication with credentials {}", credentials);
+
+        // Derive realm from the target hostname before login so the temp krb5.conf is ready
+        // when Krb5LoginModule calls Config.refresh() via refreshKrb5Config=true below.
+        // Config.getDefaultRealm() reads only from the parsed krb5.conf file — the
+        // java.security.krb5.realm system property feeds a different code path and never
+        // reaches getDefaultRealm().
+        final String hostname = bookmark.getHostname();
+        final String[] parts = hostname.split("\\.");
+        final String savedKrb5Conf = System.getProperty("java.security.krb5.conf");
+        final String savedSubjectCredsOnly = System.getProperty("javax.security.auth.useSubjectCredsOnly");
+        File krb5conf = null;
+        if(parts.length >= 2) {
+            final String realm = (parts[parts.length - 2] + "." + parts[parts.length - 1]).toUpperCase(java.util.Locale.ROOT);
+            log.debug("Derived Kerberos realm {} from hostname {}", realm, hostname);
+            try {
+                krb5conf = File.createTempFile("cyberduck-krb5-", ".conf");
+                krb5conf.deleteOnExit();
+                try(PrintWriter w = new PrintWriter(krb5conf)) {
+                    w.println("[libdefaults]");
+                    w.println("    default_realm = " + realm);
+                    w.println("    dns_lookup_kdc = true");
+                }
+                System.setProperty("java.security.krb5.conf", krb5conf.getAbsolutePath());
+            }
+            catch(IOException e) {
+                log.warn("Failed to write temporary krb5.conf for realm {}: {}", realm, e.getMessage());
+            }
+        }
+
+        LoginContext loginContext = null;
+        boolean loggedIn = false;
+        try {
+            // refreshKrb5Config=true tells Krb5LoginModule to call Config.refresh() at the
+            // start of login(). Since the module runs inside java.security.jgss it can access
+            // sun.security.krb5.Config directly, bypassing the module encapsulation that blocks
+            // our own reflection calls.
+            final Configuration jaasConfig = new Configuration() {
+                @Override
+                public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
+                    final Map<String, String> options = new HashMap<>();
+                    options.put("useTicketCache", "true");
+                    options.put("renewTGT", "true");
+                    options.put("doNotPrompt", "true");
+                    options.put("refreshKrb5Config", "true");
+                    return new AppConfigurationEntry[]{
+                        new AppConfigurationEntry(
+                            "com.sun.security.auth.module.Krb5LoginModule",
+                            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                            options)
+                    };
+                }
+            };
+            loginContext = new LoginContext("cyberduck-sftp", new Subject(), null, jaasConfig);
+            loginContext.login();
+            loggedIn = true;
+            log.debug("Kerberos TGT acquired for principal {}", loginContext.getSubject());
+            final List<Oid> mechanisms = Collections.singletonList(KRB5_MECH);
+            System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
+            try {
+                client.auth(credentials.getUsername(), new AuthGssApiWithMic(loginContext, mechanisms));
+            }
+            finally {
+                if(savedKrb5Conf != null) {
+                    System.setProperty("java.security.krb5.conf", savedKrb5Conf);
+                }
+                else {
+                    System.clearProperty("java.security.krb5.conf");
+                }
+                if(savedSubjectCredsOnly != null) {
+                    System.setProperty("javax.security.auth.useSubjectCredsOnly", savedSubjectCredsOnly);
+                }
+                else {
+                    System.clearProperty("javax.security.auth.useSubjectCredsOnly");
+                }
+                if(krb5conf != null) {
+                    krb5conf.delete();
+                }
+            }
+            final boolean authenticated = client.isAuthenticated();
+            log.debug("GSS-API authentication result: authenticated={}, partialSuccess={}", authenticated,
+                    client.getUserAuth().hadPartialSuccess());
+            return authenticated;
+        }
+        catch(IOException e) {
+            log.warn("GSS-API authentication failed for {}", bookmark.getHostname(), e);
+            throw new SFTPExceptionMappingService().map(e);
+        }
+        catch(LoginException e) {
+            // No TGT in cache or Kerberos not configured. Fall through to next auth method.
+            log.warn("GSS-API login failed for {}: {}", bookmark.getHostname(), e.getMessage());
+            return false;
+        }
+        finally {
+            if(loggedIn) {
+                try {
+                    loginContext.logout();
+                }
+                catch(LoginException e) {
+                    log.warn("Failed to logout GSS context: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getMethod() {
+        return "gssapi-with-mic";
+    }
+}

--- a/ssh/src/test/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthenticationTest.java
+++ b/ssh/src/test/java/ch/cyberduck/core/sftp/auth/SFTPGssApiAuthenticationTest.java
@@ -1,0 +1,88 @@
+package ch.cyberduck.core.sftp.auth;
+
+/*
+ * Copyright (c) 2002-2024 iterate GmbH. All rights reserved.
+ * https://cyberduck.io/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+import ch.cyberduck.core.Credentials;
+import ch.cyberduck.core.Host;
+import ch.cyberduck.core.LoginCallback;
+import ch.cyberduck.core.sftp.SFTPProtocol;
+import ch.cyberduck.core.threading.CancelCallback;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import static org.junit.Assert.*;
+
+public class SFTPGssApiAuthenticationTest {
+
+    private String savedKrb5Conf;
+
+    @Before
+    public void saveKrb5Conf() {
+        savedKrb5Conf = System.getProperty("java.security.krb5.conf");
+    }
+
+    @After
+    public void restoreKrb5Conf() {
+        if(savedKrb5Conf != null) {
+            System.setProperty("java.security.krb5.conf", savedKrb5Conf);
+        }
+        else {
+            System.clearProperty("java.security.krb5.conf");
+        }
+    }
+
+    @Test
+    public void testGetMethod() {
+        assertEquals("gssapi-with-mic", new SFTPGssApiAuthentication(null).getMethod());
+    }
+
+    @Test
+    public void testAuthenticateNoTgtReturnsFalseWithPresetKrb5Conf() throws Exception {
+        // When java.security.krb5.conf is already set, the code must leave it unchanged on exit —
+        // even when loginContext.login() fails because no TGT is available.
+        final File sentinel = File.createTempFile("cyberduck-test-krb5-", ".conf");
+        sentinel.deleteOnExit();
+        try(PrintWriter w = new PrintWriter(sentinel)) {
+            w.println("[libdefaults]");
+            w.println("    default_realm = NONEXISTENT.INVALID");
+        }
+        System.setProperty("java.security.krb5.conf", sentinel.getAbsolutePath());
+
+        final Host host = new Host(new SFTPProtocol(), "test.nonexistent.invalid", new Credentials("user", ""));
+        // No TGT exists for NONEXISTENT.INVALID; login fails and authenticate() must return false.
+        assertFalse(new SFTPGssApiAuthentication(null).authenticate(host, LoginCallback.noop, CancelCallback.noop));
+        assertEquals("java.security.krb5.conf must be unchanged after login failure",
+                sentinel.getAbsolutePath(), System.getProperty("java.security.krb5.conf"));
+        sentinel.delete();
+    }
+
+    @Test
+    public void testAuthenticateNoTgtClearsTemporaryKrb5Conf() throws Exception {
+        // When no java.security.krb5.conf is set, the code writes a temp file and sets the property.
+        // After login failure the property must be cleared so subsequent auth methods see a clean state.
+        System.clearProperty("java.security.krb5.conf");
+
+        final Host host = new Host(new SFTPProtocol(), "test.nonexistent.invalid", new Credentials("user", ""));
+        assertFalse(new SFTPGssApiAuthentication(null).authenticate(host, LoginCallback.noop, CancelCallback.noop));
+        assertNull("java.security.krb5.conf must be cleared after login failure",
+                System.getProperty("java.security.krb5.conf"));
+    }
+}


### PR DESCRIPTION
Adds SFTPGssApiAuthentication, a new authentication provider that supports gssapi-with-mic (Kerberos v5) for SFTP connections.
                                                                                                                                                                                                                                                
The implementation uses JAAS Krb5LoginModule with useTicketCache=true to check for an existing TGT. If no TGT is present, the method returns false and login falls through to the next available method. The provider is inserted after public key authentication in the method list so that servers requiring both (AuthenticationMethods publickey,gssapi-with-mic) work correctly: public key obtains partial success, then GSSAPI completes the second factor.
                                                                                                                                                                                                                                                
On macOS, Java's JGSS cannot locate krb5.conf through its standard search paths, and dns_lookup_kdc is disabled by default in Java 9+. To work around this, the implementation derives the Kerberos realm from the target hostname, writes a minimal temp krb5.conf with default_realm and dns_lookup_kdc=true, and uses the refreshKrb5Config=true JAAS option to reload the configuration from within the java.security.jgss module.

This resolves #12082
