### PR TITLE
Add workflow_dispatch placeholders on master for new publish workflows

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -1,0 +1,14 @@
+name: Publish Mac App Store
+
+# Placeholder on master. The real implementation lives on feature branches and
+# replaces this file when merged. It exists here only so the workflow can be
+# started with workflow_dispatch against a feature branch that implements it.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Placeholder. Run this workflow from a feature branch that implements it."

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,14 @@
+name: Publish Beta
+
+# Placeholder on master. The real implementation lives on feature branches and
+# replaces this file when merged. It exists here only so the workflow can be
+# started with workflow_dispatch against a feature branch that implements it.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Placeholder. Run this workflow from a feature branch that implements it."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Publish Release
+
+# Placeholder on master. The real implementation lives on feature branches and
+# replaces this file when merged. It exists here only so the workflow can be
+# started with workflow_dispatch against a feature branch that implements it.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Placeholder. Run this workflow from a feature branch that implements it."

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,14 @@
+name: Publish Snapshot
+
+# Placeholder on master. The real implementation lives on feature branches and
+# replaces this file when merged. It exists here only so the workflow can be
+# started with workflow_dispatch against a feature branch that implements it.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Placeholder. Run this workflow from a feature branch that implements it."


### PR DESCRIPTION
The `feature/GH-14998` branch in #17126 introduces new publish workflows (`snapshot.yml`, `release.yml`, `appstore.yml`, `beta.yml`). GitHub only exposes `workflow_dispatch` for a workflow when the workflow file exists on the default branch, so these cannot be manually triggered against the feature branch until master carries at least a stub.

This adds no-op placeholders for each. Each is `workflow_dispatch`-only with a single `echo` step. When `feature/GH-14998` merges, the real implementations replace these files.

`publish.yml` needs no placeholder: it is `workflow_call`-only and local reusable workflows resolve against the ref of the calling workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
